### PR TITLE
Add tabbed teacher, room, and day planning views

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,42 +30,61 @@
         <!-- Cartes d'information -->
         <div id="info-cards" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8"></div>
 
-        <!-- Planning des surveillances -->
+        <!-- Vues dynamiques -->
         <div class="bg-white p-6 rounded-xl shadow-md border border-slate-200">
-            <h2 class="text-xl font-semibold mb-4">Planning des Surveillances</h2>
-            <div class="overflow-x-auto">
-                <table class="w-full text-sm text-left text-slate-600">
-                    <thead class="text-xs text-slate-700 uppercase bg-slate-100">
-                        <tr>
-                            <th scope="col" class="px-6 py-3 rounded-l-lg">Professeur</th>
-                            <th scope="col" class="px-6 py-3">Date &amp; Heure Début</th>
-                            <th scope="col" class="px-6 py-3">Salle</th>
-                            <th scope="col" class="px-6 py-3">Mission</th>
-                            <th scope="col" class="px-6 py-3 rounded-r-lg">Durée</th>
-                        </tr>
-                    </thead>
-                    <tbody id="surveillance-body" class="divide-y divide-slate-200"></tbody>
-                </table>
+            <div class="flex flex-wrap items-center gap-2 border-b border-slate-200 pb-4">
+                <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="teacher" data-view-default>
+                    <i data-lucide="users"></i>
+                    <span>Vue par enseignant</span>
+                </button>
+                <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="room">
+                    <i data-lucide="layout-grid"></i>
+                    <span>Vue par salle</span>
+                </button>
+                <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="day">
+                    <i data-lucide="calendar"></i>
+                    <span>Vue par jour</span>
+                </button>
             </div>
-        </div>
 
-        <!-- Planning par Salle -->
-        <div class="bg-white p-6 rounded-xl shadow-md border border-slate-200 mt-8">
-            <h2 class="text-xl font-semibold mb-4">Planning par Salle</h2>
-            <div class="overflow-x-auto">
-                <table class="w-full text-sm text-left text-slate-600">
-                    <thead class="text-xs text-slate-700 uppercase bg-slate-100">
-                        <tr>
-                            <th scope="col" class="px-6 py-3 rounded-l-lg">Jour</th>
-                            <th scope="col" class="px-6 py-3 text-center">S9 PRIO / EPS</th>
-                            <th scope="col" class="px-6 py-3 text-center">S10</th>
-                            <th scope="col" class="px-6 py-3 text-center">S12</th>
-                            <th scope="col" class="px-6 py-3 text-center">S13</th>
-                            <th scope="col" class="px-6 py-3 text-center rounded-r-lg">S14</th>
-                        </tr>
-                    </thead>
-                    <tbody id="room-schedule" class="divide-y divide-slate-200 align-top"></tbody>
-                </table>
+            <div class="mt-6 space-y-10">
+                <section id="teacher-view" data-view-section="teacher" class="space-y-6">
+                    <div>
+                        <h2 class="text-xl font-semibold text-slate-900">Planning des missions par enseignant</h2>
+                        <p class="text-sm text-slate-500">Visualisez le détail des missions pour chaque professeur, avec les horaires, salles et durées totales.</p>
+                    </div>
+                    <div id="teacher-schedule" class="grid gap-4 md:grid-cols-2"></div>
+                </section>
+
+                <section id="room-view" data-view-section="room" class="space-y-6 hidden">
+                    <div>
+                        <h2 class="text-xl font-semibold text-slate-900">Planning par salle</h2>
+                        <p class="text-sm text-slate-500">Chaque créneau est surligné selon le bloc horaire (matin, après-midi, etc.) pour faciliter la lecture.</p>
+                    </div>
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-sm text-left text-slate-600">
+                            <thead class="text-xs text-slate-700 uppercase bg-slate-100">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3 rounded-l-lg">Jour</th>
+                                    <th scope="col" class="px-6 py-3 text-center">S9 PRIO / EPS</th>
+                                    <th scope="col" class="px-6 py-3 text-center">S10</th>
+                                    <th scope="col" class="px-6 py-3 text-center">S12</th>
+                                    <th scope="col" class="px-6 py-3 text-center">S13</th>
+                                    <th scope="col" class="px-6 py-3 text-center rounded-r-lg">S14</th>
+                                </tr>
+                            </thead>
+                            <tbody id="room-schedule" class="divide-y divide-slate-200 align-top"></tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section id="day-view" data-view-section="day" class="space-y-6 hidden">
+                    <div>
+                        <h2 class="text-xl font-semibold text-slate-900">Planning condensé par jour</h2>
+                        <p class="text-sm text-slate-500">Retrouvez une vue globale de chaque journée, organisée par créneaux horaires comme dans un emploi du temps.</p>
+                    </div>
+                    <div id="day-schedule" class="space-y-4"></div>
+                </section>
             </div>
         </div>
 
@@ -245,8 +264,9 @@
         ];
 
         const infoCardsContainer = document.getElementById('info-cards');
-        const surveillanceBody = document.getElementById('surveillance-body');
+        const teacherScheduleContainer = document.getElementById('teacher-schedule');
         const roomBody = document.getElementById('room-schedule');
+        const dayScheduleContainer = document.getElementById('day-schedule');
 
         function renderKeyFiguresCard(figures) {
             const stats = figures.map(renderKeyFigure).join('');
@@ -300,35 +320,351 @@
             `;
         }
 
-        function renderSurveillanceRow({ teacher, datetime, room, mission, duration, type }) {
-            const rowClasses = ['transition-colors', 'hover:bg-slate-50'];
-            const isToday = isDatetimeToday(datetime);
+        function buildTeacherSchedule(schedule) {
+            const teacherMap = new Map();
 
-            if (isToday) {
-                rowClasses.push('bg-amber-50/70');
-            }
+            schedule.forEach((entry) => {
+                const teacherName = entry.teacher && entry.teacher.trim() ? entry.teacher.trim() : 'À assigner';
+                if (!teacherMap.has(teacherName)) {
+                    teacherMap.set(teacherName, []);
+                }
+                teacherMap.get(teacherName).push(entry);
+            });
 
-            const teacherContent = teacher
-                ? teacher
-                : '<span class="text-slate-400 italic">À confirmer</span>';
+            const teachers = Array.from(teacherMap.entries()).map(([teacher, missions]) => ({ teacher, missions }));
 
-            const roomContent = room && room !== '-'
-                ? room
-                : '<span class="text-slate-400 italic">À préciser</span>';
+            teachers.sort((a, b) => {
+                if (a.teacher === 'À assigner') {
+                    return 1;
+                }
+                if (b.teacher === 'À assigner') {
+                    return -1;
+                }
+                return a.teacher.localeCompare(b.teacher, 'fr', { sensitivity: 'base' });
+            });
 
-            const datetimeContent = isToday
-                ? `<div class="flex items-center gap-2">${datetime}${renderTodayBadge()}</div>`
-                : datetime;
+            return teachers;
+        }
+
+        function renderTeacherCard({ teacher, missions }) {
+            const totalSeconds = missions.reduce((sum, mission) => sum + parseDuration(mission.duration), 0);
+            const summary = `${missions.length} mission${missions.length > 1 ? 's' : ''} • ${formatDuration(totalSeconds)}`;
+            const description = teacher === 'À assigner'
+                ? 'Missions en attente d’assignation'
+                : 'Planning confirmé';
+            const badgeClasses = teacher === 'À assigner'
+                ? 'bg-amber-200/80 text-amber-900'
+                : 'bg-slate-200/80 text-slate-600';
+            const badgeIcon = teacher === 'À assigner' ? 'alert-circle' : 'clipboard-list';
+            const missionList = missions
+                .map((mission) => renderTeacherMission(mission))
+                .join('');
 
             return `
-                <tr class="${rowClasses.join(' ')}">
-                    <td class="px-6 py-4 font-medium text-slate-900">${teacherContent}</td>
-                    <td class="px-6 py-4">${datetimeContent}</td>
-                    <td class="px-6 py-4">${roomContent}</td>
-                    <td class="px-6 py-4">${renderMissionDetails(mission, type)}</td>
-                    <td class="px-6 py-4">${duration}</td>
-                </tr>
+                <article class="rounded-xl border border-slate-200 bg-slate-50 p-4 shadow-sm transition hover:shadow">
+                    <div class="flex items-start justify-between gap-4">
+                        <div>
+                            <h3 class="text-lg font-semibold text-slate-900">${teacher}</h3>
+                            <p class="text-sm text-slate-500">${summary}</p>
+                        </div>
+                        <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClasses}">
+                            <i data-lucide="${badgeIcon}" class="h-3.5 w-3.5"></i>
+                            ${description}
+                        </span>
+                    </div>
+                    <div class="mt-4 space-y-3">
+                        ${missionList}
+                    </div>
+                </article>
             `;
+        }
+
+        function renderTeacherMission(mission) {
+            const typeBadge = mission.type ? renderTypeBadge(mission.type, { compact: true }) : '';
+            const isToday = isDatetimeToday(mission.datetime);
+            const datetimeContent = isToday
+                ? `<div class="flex items-center gap-2">${mission.datetime}${renderTodayBadge()}</div>`
+                : mission.datetime;
+            const roomContent = mission.room && mission.room !== '-'
+                ? mission.room
+                : '<span class="italic text-slate-400">Salle à confirmer</span>';
+            const durationValue = mission.duration
+                ? formatDuration(parseDuration(mission.duration))
+                : 'Durée à préciser';
+
+            return `
+                <div class="rounded-lg border border-slate-200 bg-white/80 p-3">
+                    <div class="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
+                        <div class="flex items-center gap-2 text-slate-600">
+                            <i data-lucide="calendar-clock" class="h-4 w-4"></i>
+                            ${datetimeContent}
+                        </div>
+                        ${typeBadge}
+                    </div>
+                    <p class="mt-2 text-sm font-semibold text-slate-900">${mission.mission}</p>
+                    <div class="mt-2 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                        <span class="inline-flex items-center gap-1">
+                            <i data-lucide="map-pin" class="h-3.5 w-3.5"></i>
+                            ${roomContent}
+                        </span>
+                        <span class="inline-flex items-center gap-1">
+                            <i data-lucide="clock-3" class="h-3.5 w-3.5"></i>
+                            ${durationValue}
+                        </span>
+                    </div>
+                </div>
+            `;
+        }
+
+        function parseDuration(duration) {
+            if (!duration) {
+                return 0;
+            }
+
+            const [hours = 0, minutes = 0, seconds = 0] = duration.split(':').map(Number);
+            return (hours * 3600) + (minutes * 60) + seconds;
+        }
+
+        function formatDuration(totalSeconds) {
+            const hours = Math.floor(totalSeconds / 3600);
+            const minutes = Math.floor((totalSeconds % 3600) / 60);
+            const parts = [];
+
+            if (hours) {
+                parts.push(`${hours}\u202fh`);
+            }
+
+            if (minutes) {
+                parts.push(`${minutes}\u202fmin`);
+            }
+
+            return parts.length > 0 ? parts.join(' ') : '0 min';
+        }
+
+        function buildDaySchedule(schedule) {
+            return schedule.map(({ day, rooms }) => {
+                const slotMap = new Map();
+                const slots = [];
+
+                Object.entries(rooms).forEach(([room, sessions]) => {
+                    sessions.forEach((session) => {
+                        const key = session.time || session.label || 'Horaire à confirmer';
+
+                        if (!slotMap.has(key)) {
+                            const slot = {
+                                key,
+                                time: session.time || null,
+                                label: session.label || null,
+                                entries: []
+                            };
+                            slotMap.set(key, slot);
+                            slots.push(slot);
+                        }
+
+                        slotMap.get(key).entries.push({
+                            room,
+                            teacher: session.teacher,
+                            detail: session.detail,
+                            type: session.type,
+                            highlight: session.highlight,
+                            time: session.time,
+                            label: session.label
+                        });
+                    });
+                });
+
+                slots.sort((a, b) => {
+                    const hourA = extractStartHour(a.time);
+                    const hourB = extractStartHour(b.time);
+
+                    if (hourA !== null && hourB !== null) {
+                        return hourA - hourB;
+                    }
+
+                    if (hourA !== null) {
+                        return -1;
+                    }
+
+                    if (hourB !== null) {
+                        return 1;
+                    }
+
+                    return (a.label || '').localeCompare(b.label || '', 'fr', { sensitivity: 'base' });
+                });
+
+                return { day, slots };
+            });
+        }
+
+        function renderDayCard({ day, slots }) {
+            const isToday = isDayLabelToday(day);
+            const badge = isToday ? renderTodayBadge() : '';
+            const content = slots.length
+                ? slots.map((slot) => renderDaySlot(slot)).join('')
+                : renderEmptyState('Aucun créneau planifié pour cette journée.');
+
+            return `
+                <article class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                    <div class="flex flex-wrap items-center justify-between gap-2">
+                        <h3 class="text-lg font-semibold text-slate-900">${day}</h3>
+                        ${badge}
+                    </div>
+                    <div class="mt-4 space-y-4">
+                        ${content}
+                    </div>
+                </article>
+            `;
+        }
+
+        function renderDaySlot(slot) {
+            const highlight = getBlockHighlight(slot);
+            const slotClasses = ['rounded-lg', 'border', 'border-slate-200', 'bg-slate-50', 'p-3'];
+
+            if (highlight) {
+                slotClasses.push(highlight.background, highlight.border);
+            }
+
+            const label = slot.label && (!slot.time || slot.label !== slot.time)
+                ? renderBlockLabel(slot, highlight)
+                : '';
+
+            const entries = slot.entries.length
+                ? slot.entries.map((entry) => renderDaySession(entry)).join('')
+                : `<p class="text-xs italic text-slate-400">Aucune surveillance prévue.</p>`;
+
+            return `
+                <div class="${slotClasses.join(' ')}">
+                    <div class="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
+                        <div class="flex items-center gap-2">
+                            <i data-lucide="clock" class="h-4 w-4 text-slate-500"></i>
+                            ${slot.time || slot.label || 'Horaire à confirmer'}
+                        </div>
+                        ${label}
+                    </div>
+                    <div class="mt-3 grid gap-3 md:grid-cols-2">
+                        ${entries}
+                    </div>
+                </div>
+            `;
+        }
+
+        function renderDaySession(entry) {
+            const badge = entry.type ? renderTypeBadge(entry.type, { compact: true }) : '';
+            const teacherContent = entry.teacher
+                ? `<span class="font-semibold text-slate-900">${entry.teacher}</span>`
+                : '<span class="italic text-slate-400">Surveillant à confirmer</span>';
+            const detailContent = entry.detail ? `<p class="text-xs text-slate-500">${entry.detail}</p>` : '';
+            const wrapperClasses = ['rounded-lg', 'border', 'border-slate-200', 'bg-white', 'p-3', 'shadow-sm'];
+
+            if (entry.highlight) {
+                wrapperClasses.push('ring-2', 'ring-amber-300/70');
+            }
+
+            return `
+                <div class="${wrapperClasses.join(' ')}">
+                    <div class="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        <span>${entry.room}</span>
+                        ${badge}
+                    </div>
+                    <div class="mt-2 text-sm text-slate-700">
+                        ${teacherContent}
+                    </div>
+                    ${detailContent}
+                </div>
+            `;
+        }
+
+        function renderEmptyState(message) {
+            return `
+                <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
+                    ${message}
+                </div>
+            `;
+        }
+
+        function getBlockHighlight({ label, time }) {
+            const normalizedLabel = (label || '').toLowerCase();
+            const startHour = extractStartHour(time);
+
+            if (normalizedLabel.includes('matin') || (startHour !== null && startHour < 12)) {
+                return {
+                    background: 'bg-sky-50',
+                    border: 'border-sky-200',
+                    badgeBackground: 'bg-sky-200/70',
+                    badgeText: 'text-sky-900'
+                };
+            }
+
+            if (normalizedLabel.includes('après') || normalizedLabel.includes('apres') || (startHour !== null && startHour >= 12)) {
+                return {
+                    background: 'bg-rose-50',
+                    border: 'border-rose-200',
+                    badgeBackground: 'bg-rose-200/70',
+                    badgeText: 'text-rose-900'
+                };
+            }
+
+            return null;
+        }
+
+        function renderBlockLabel(session, highlight) {
+            const classes = ['inline-flex', 'items-center', 'gap-1', 'rounded-full', 'px-2', 'py-0.5', 'text-[10px]', 'font-semibold', 'uppercase', 'tracking-wide'];
+
+            if (highlight) {
+                classes.push(highlight.badgeBackground, highlight.badgeText);
+            } else {
+                classes.push('bg-slate-200', 'text-slate-600');
+            }
+
+            return `<span class="${classes.join(' ')}">${session.label}</span>`;
+        }
+
+        function extractStartHour(time) {
+            if (!time) {
+                return null;
+            }
+
+            const match = time.match(/(\d{1,2})h/);
+            if (!match) {
+                return null;
+            }
+
+            return Number(match[1]);
+        }
+
+        function setupViewTabs() {
+            const buttons = document.querySelectorAll('[data-view-target]');
+            const sections = document.querySelectorAll('[data-view-section]');
+
+            if (!buttons.length || !sections.length) {
+                return;
+            }
+
+            const setActiveView = (view) => {
+                sections.forEach((section) => {
+                    section.classList.toggle('hidden', section.dataset.viewSection !== view);
+                });
+
+                buttons.forEach((button) => {
+                    const isActive = button.dataset.viewTarget === view;
+                    button.setAttribute('aria-pressed', String(isActive));
+                    if (isActive) {
+                        button.classList.remove('bg-slate-100', 'text-slate-600');
+                        button.classList.add('bg-blue-600', 'text-white', 'shadow');
+                    } else {
+                        button.classList.add('bg-slate-100', 'text-slate-600');
+                        button.classList.remove('bg-blue-600', 'text-white', 'shadow');
+                    }
+                });
+            };
+
+            buttons.forEach((button) => {
+                button.addEventListener('click', () => setActiveView(button.dataset.viewTarget));
+            });
+
+            const defaultButton = document.querySelector('[data-view-default]');
+            const defaultView = defaultButton ? defaultButton.dataset.viewTarget : buttons[0].dataset.viewTarget;
+            setActiveView(defaultView);
         }
 
         function renderRoomRow({ day, rooms }) {
@@ -357,7 +693,7 @@
                 return '<td class="px-6 py-4 text-center"></td>';
             }
 
-            const sessionCards = sessions.map(renderSessionCard).join('');
+            const sessionCards = sessions.map((session) => renderSessionCard(session)).join('');
             const containerClasses = sessions.length > 1
                 ? 'flex flex-col gap-3 items-stretch'
                 : 'flex justify-center items-center';
@@ -373,15 +709,18 @@
 
         function renderSessionCard(session) {
             const typeConfig = getTypeConfig(session.type);
+            const blockHighlight = getBlockHighlight(session);
             const baseClasses = ['rounded-lg', 'border', 'p-3', 'flex', 'flex-col', 'gap-2', 'items-center', typeConfig.cardBorder, typeConfig.cardBackground];
+
+            if (blockHighlight) {
+                baseClasses.push(blockHighlight.background, blockHighlight.border);
+            }
 
             if (session.highlight) {
                 baseClasses.push('ring-2', 'ring-amber-300', 'shadow-sm');
             }
 
-            const label = session.label
-                ? `<div class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">${session.label}</div>`
-                : '';
+            const label = session.label ? renderBlockLabel(session, blockHighlight) : '';
 
             const typeBadge = session.type ? renderTypeBadge(session.type, { compact: true }) : '';
             const header = label || typeBadge
@@ -390,8 +729,10 @@
 
             const time = session.time
                 ? `<div class="text-xs font-semibold text-slate-700">${session.time}</div>`
-                : '<div class="text-xs text-slate-400 italic">—</div>';
-            const teacher = session.teacher ? `<div class="text-sm font-semibold ${typeConfig.textColor}">${session.teacher}</div>` : '';
+                : '<div class="text-xs text-slate-400 italic">Horaire à confirmer</div>';
+            const teacher = session.teacher
+                ? `<div class="text-sm font-semibold ${typeConfig.textColor}">${session.teacher}</div>`
+                : '<div class="text-xs italic text-slate-400">Surveillant à confirmer</div>';
             const detail = session.detail ? `<div class="text-xs text-slate-600">${session.detail}</div>` : '';
 
             return `
@@ -421,16 +762,6 @@
                     <i data-lucide="${typeConfig.icon}" class="${iconSize} ${typeConfig.iconColor}"></i>
                     ${typeConfig.label}
                 </span>
-            `;
-        }
-
-        function renderMissionDetails(mission, type) {
-            const badge = renderTypeBadge(type);
-            return `
-                <div class="flex flex-col gap-2 text-slate-700">
-                    ${badge}
-                    <span class="text-sm text-slate-600">${mission}</span>
-                </div>
             `;
         }
 
@@ -475,9 +806,19 @@
 
         document.addEventListener('DOMContentLoaded', () => {
             const cardsMarkup = [renderKeyFiguresCard(keyFigures), ...accommodationGroups.map(renderAccommodationCard)];
+            const teacherSchedule = buildTeacherSchedule(surveillanceSchedule);
+            const daySchedule = buildDaySchedule(roomSchedule);
+
             infoCardsContainer.innerHTML = cardsMarkup.join('');
-            surveillanceBody.innerHTML = surveillanceSchedule.map(renderSurveillanceRow).join('');
-            roomBody.innerHTML = roomSchedule.map(renderRoomRow).join('');
+            teacherScheduleContainer.innerHTML = teacherSchedule.length
+                ? teacherSchedule.map((item) => renderTeacherCard(item)).join('')
+                : renderEmptyState('Aucune mission de surveillance enregistrée pour le moment.');
+            roomBody.innerHTML = roomSchedule.map((row) => renderRoomRow(row)).join('');
+            dayScheduleContainer.innerHTML = daySchedule.length
+                ? daySchedule.map((item) => renderDayCard(item)).join('')
+                : renderEmptyState('Aucune journée planifiée.');
+
+            setupViewTabs();
             lucide.createIcons();
         });
     </script>


### PR DESCRIPTION
## Summary
- introduce a tabbed navigation component to switch between teacher, room, and day planning views
- aggregate surveillance data per teacher with mission cards and total durations
- enrich room and day schedules with block-aware highlighting and a condensed daily timetable renderer

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dad2f176248331aec92a5f7e745fe2