### PR TITLE
Refactor dashboard structure and rendering logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,454 +13,602 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc; /* slate-50 */
         }
     </style>
 </head>
-<body class="text-slate-800">
-
-    <div class="container mx-auto p-4 sm:p-6 lg:p-8">
-
-        <!-- En-tête -->
-        <header class="mb-8">
+<body class="bg-slate-50 text-slate-800">
+    <div class="container mx-auto space-y-8 p-4 sm:p-6 lg:p-8">
+        <header class="space-y-2">
             <h1 class="text-3xl font-bold text-slate-900">Tableau de Bord - Baccalauréat Blanc</h1>
             <p class="text-lg text-slate-600">10, 11 et 12 Décembre 2025</p>
         </header>
 
-        <!-- Cartes d'information -->
-        <div id="info-cards" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8"></div>
+        <main class="space-y-8">
+            <section aria-labelledby="overview-title" class="space-y-4">
+                <h2 id="overview-title" class="sr-only">Informations générales</h2>
+                <div data-slot="info-cards" class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3"></div>
+            </section>
 
-        <!-- Vues dynamiques -->
-        <div class="bg-white p-6 rounded-xl shadow-md border border-slate-200">
-            <div class="flex flex-wrap items-center gap-2 border-b border-slate-200 pb-4">
-                <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="teacher" data-view-default>
-                    <i data-lucide="users"></i>
-                    <span>Vue par enseignant</span>
-                </button>
-                <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="room">
-                    <i data-lucide="layout-grid"></i>
-                    <span>Vue par salle</span>
-                </button>
-                <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="day">
-                    <i data-lucide="calendar"></i>
-                    <span>Vue par jour</span>
-                </button>
-            </div>
-
-            <div class="mt-6 space-y-10">
-                <section id="teacher-view" data-view-section="teacher" class="space-y-6">
-                    <div>
-                        <h2 class="text-xl font-semibold text-slate-900">Planning des missions par enseignant</h2>
-                        <p class="text-sm text-slate-500">Visualisez le détail des missions pour chaque professeur, avec les horaires, salles et durées totales.</p>
+            <section aria-labelledby="views-title" class="space-y-6">
+                <div class="bg-white rounded-xl border border-slate-200 p-6 shadow-md">
+                    <div class="flex flex-wrap items-center gap-2 border-b border-slate-200 pb-4" role="tablist" aria-label="Affichage des plannings">
+                        <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="teacher" data-view-default role="tab" aria-controls="teacher-view">
+                            <i data-lucide="users"></i>
+                            <span>Vue par enseignant</span>
+                        </button>
+                        <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="room" role="tab" aria-controls="room-view">
+                            <i data-lucide="layout-grid"></i>
+                            <span>Vue par salle</span>
+                        </button>
+                        <button type="button" class="view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors bg-slate-100 text-slate-600 hover:bg-slate-200" data-view-target="day" role="tab" aria-controls="day-view">
+                            <i data-lucide="calendar"></i>
+                            <span>Vue par jour</span>
+                        </button>
                     </div>
-                    <div id="teacher-schedule" class="grid gap-4 md:grid-cols-2"></div>
-                </section>
 
-                <section id="room-view" data-view-section="room" class="space-y-6 hidden">
-                    <div>
-                        <h2 class="text-xl font-semibold text-slate-900">Planning par salle</h2>
-                        <p class="text-sm text-slate-500">Chaque créneau est surligné selon le bloc horaire (matin, après-midi, etc.) pour faciliter la lecture.</p>
-                    </div>
-                    <div class="overflow-x-auto">
-                        <table class="w-full text-sm text-left text-slate-600">
-                            <thead class="text-xs text-slate-700 uppercase bg-slate-100">
-                                <tr>
-                                    <th scope="col" class="px-6 py-3 rounded-l-lg">Jour</th>
-                                    <th scope="col" class="px-6 py-3 text-center">S9 PRIO / EPS</th>
-                                    <th scope="col" class="px-6 py-3 text-center">S10</th>
-                                    <th scope="col" class="px-6 py-3 text-center">S12</th>
-                                    <th scope="col" class="px-6 py-3 text-center">S13</th>
-                                    <th scope="col" class="px-6 py-3 text-center rounded-r-lg">S14</th>
-                                </tr>
-                            </thead>
-                            <tbody id="room-schedule" class="divide-y divide-slate-200 align-top"></tbody>
-                        </table>
-                    </div>
-                </section>
+                    <div class="mt-6 space-y-10">
+                        <section id="teacher-view" data-view-section="teacher" class="space-y-6" role="tabpanel" tabindex="0">
+                            <div>
+                                <h3 class="text-xl font-semibold text-slate-900">Planning des missions par enseignant</h3>
+                                <p class="text-sm text-slate-500">Visualisez le détail des missions pour chaque professeur, avec les horaires, salles et durées totales.</p>
+                            </div>
+                            <div data-slot="teacher-schedule" class="grid gap-4 md:grid-cols-2"></div>
+                        </section>
 
-                <section id="day-view" data-view-section="day" class="space-y-6 hidden">
-                    <div>
-                        <h2 class="text-xl font-semibold text-slate-900">Planning condensé par jour</h2>
-                        <p class="text-sm text-slate-500">Retrouvez une vue globale de chaque journée, organisée par créneaux horaires comme dans un emploi du temps.</p>
-                    </div>
-                    <div id="day-schedule" class="space-y-4"></div>
-                </section>
-            </div>
-        </div>
+                        <section id="room-view" data-view-section="room" class="hidden space-y-6" role="tabpanel" tabindex="0">
+                            <div>
+                                <h3 class="text-xl font-semibold text-slate-900">Planning par salle</h3>
+                                <p class="text-sm text-slate-500">Chaque créneau est surligné selon le bloc horaire (matin, après-midi, etc.) pour faciliter la lecture.</p>
+                            </div>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-left text-sm text-slate-600">
+                                    <thead class="bg-slate-100 text-xs uppercase text-slate-700">
+                                        <tr>
+                                            <th scope="col" class="rounded-l-lg px-6 py-3">Jour</th>
+                                            <th scope="col" class="px-6 py-3 text-center">S9 PRIO / EPS</th>
+                                            <th scope="col" class="px-6 py-3 text-center">S10</th>
+                                            <th scope="col" class="px-6 py-3 text-center">S12</th>
+                                            <th scope="col" class="px-6 py-3 text-center">S13</th>
+                                            <th scope="col" class="rounded-r-lg px-6 py-3 text-center">S14</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody data-slot="room-schedule" class="align-top divide-y divide-slate-200"></tbody>
+                                </table>
+                            </div>
+                        </section>
 
-        <!-- Rappel -->
-        <footer class="mt-8 text-center p-4 bg-blue-100 text-blue-800 rounded-lg">
+                        <section id="day-view" data-view-section="day" class="hidden space-y-6" role="tabpanel" tabindex="0">
+                            <div>
+                                <h3 class="text-xl font-semibold text-slate-900">Planning condensé par jour</h3>
+                                <p class="text-sm text-slate-500">Retrouvez une vue globale de chaque journée, organisée par créneaux horaires comme dans un emploi du temps.</p>
+                            </div>
+                            <div data-slot="day-schedule" class="space-y-4"></div>
+                        </section>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <footer class="rounded-lg bg-blue-100 p-4 text-center text-blue-800">
             <p class="font-semibold">Rappel :</p>
             <p>Envoi des sujets au moins une semaine avant le bac blanc. Présence des surveillants 20 min avant le début de l'épreuve.</p>
         </footer>
-
     </div>
 
     <script>
-        const TYPE_CONFIG = {
-            philosophie: {
-                label: 'Philosophie',
-                icon: 'book-open',
-                badgeClasses: 'bg-slate-200 text-slate-700',
-                iconColor: 'text-slate-600',
-                cardBorder: 'border-slate-300',
-                cardBackground: 'bg-slate-50',
-                textColor: 'text-slate-700'
-            },
-            specialite: {
-                label: 'Spécialité',
-                icon: 'calculator',
-                badgeClasses: 'bg-blue-100 text-blue-700',
-                iconColor: 'text-blue-600',
-                cardBorder: 'border-blue-200',
-                cardBackground: 'bg-blue-50',
-                textColor: 'text-blue-700'
-            },
-            eaf: {
-                label: 'EAF',
-                icon: 'pen-line',
-                badgeClasses: 'bg-violet-100 text-violet-700',
-                iconColor: 'text-violet-600',
-                cardBorder: 'border-violet-200',
-                cardBackground: 'bg-violet-50',
-                textColor: 'text-violet-700'
-            },
-            support: {
-                label: 'Support',
-                icon: 'life-buoy',
-                badgeClasses: 'bg-amber-100 text-amber-700',
-                iconColor: 'text-amber-600',
-                cardBorder: 'border-amber-200',
-                cardBackground: 'bg-amber-50',
-                textColor: 'text-amber-700'
-            },
-            default: {
-                label: 'Épreuve',
-                icon: 'calendar-days',
-                badgeClasses: 'bg-slate-100 text-slate-700',
-                iconColor: 'text-slate-600',
-                cardBorder: 'border-slate-200',
-                cardBackground: 'bg-white',
-                textColor: 'text-slate-700'
-            }
-        };
-
-        const keyFigures = [
-            { value: '4', label: 'Salles' },
-            { value: '4', label: 'Épreuves', extra: '(dont 1 EAF 1ère)' },
-            { value: '4', unit: 'h', label: 'Durée moyenne' },
-            { value: '64', unit: 'h', label: 'Surveillance' }
-        ];
-
-        const accommodationGroups = [
-            {
-                icon: { name: 'users-2', bg: 'bg-green-100', color: 'text-green-600' },
-                title: 'Terminale',
-                description: "Liste des élèves avec aménagements d'examen :",
-                students: ['RISPAL Charlie', 'NDOUR Fatou', 'SOBLOG Oscar', 'FALL CLAMENS Omar', 'ZARB Frédy'],
-                rooms: '9, 12, 13, 14.',
-                note: 'Silence requis dans les salles 10 et 11.',
-                noteClasses: 'bg-amber-100 text-amber-800'
-            },
-            {
-                icon: { name: 'user-check', bg: 'bg-purple-100', color: 'text-purple-600' },
-                title: 'Première',
-                description: "Liste des élèves avec aménagements d'examen :",
-                students: ['JENOUDET Thiméo', 'Owen Thibault', 'SARR Sokhna Faty', 'KERDUDO Zeina'],
-                rooms: '10, 12, 13, 14.',
-                note: 'Silence requis dans la salle 11.',
-                noteClasses: 'bg-amber-100 text-amber-800'
-            }
-        ];
-
-        const surveillanceSchedule = [
-            { teacher: 'ANE A.', datetime: 'jeudi 11/12 à 08h00', room: 'S13', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '4:00:00', type: 'specialite' },
-            { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S9 PRIO / EPS', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '5:30:00', type: 'specialite' },
-            { teacher: 'BOSSU C.', datetime: 'mercredi 10/12 à 08h00', room: 'S9 PRIO / EPS', mission: 'Bac blanc de philosophie', duration: '5:30:00', type: 'philosophie' },
-            { teacher: 'DAVID V.', datetime: 'jeudi 11/12 à 08h00', room: 'S12', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '4:00:00', type: 'specialite' },
-            { teacher: 'FALL B.', datetime: 'jeudi 11/12 à 08h00', room: 'S9 PRIO / EPS', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '5:30:00', type: 'specialite' },
-            { teacher: '', datetime: 'vendredi 12/12 à 10h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:00:00', type: 'support' },
-            { teacher: 'GIBUS A.', datetime: 'mercredi 10/12 à 10h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:00:00', type: 'support' },
-            { teacher: 'GOMIS A.', datetime: 'mercredi 10/12 à 08h00', room: 'S12', mission: 'Bac blanc de philosophie', duration: '4:00:00', type: 'philosophie' },
-            { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S13', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '4:00:00', type: 'specialite' },
-            { teacher: 'JAÏT L.', datetime: 'jeudi 11/12 à 08h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:00:00', type: 'support' },
-            { teacher: '', datetime: 'jeudi 11/12 à 13h05', room: 'S12', mission: 'Bac blanc EAF', duration: '5:00:00', type: 'eaf' },
-            { teacher: 'MBOUP N.', datetime: 'jeudi 11/12 à 10h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '1:30:00', type: 'support' },
-            { teacher: '', datetime: 'jeudi 11/12 à 14h05', room: 'S10', mission: 'Bac blanc EAF', duration: '4:00:00', type: 'eaf' },
-            { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S14', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '4:00:00', type: 'specialite' },
-            { teacher: 'MICHON GUILLAUME M.', datetime: 'jeudi 11/12 à 08h00', room: 'S14', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '4:00:00', type: 'specialite' },
-            { teacher: '', datetime: 'mercredi 10/12 à 08h00', room: 'S14', mission: 'Bac blanc de philosophie', duration: '4:00:00', type: 'philosophie' },
-            { teacher: 'MOURAIN DIOP F.', datetime: 'jeudi 11/12 à 14h05', room: 'S13', mission: 'Bac blanc EAF', duration: '4:00:00', type: 'eaf' },
-            { teacher: '', datetime: 'mercredi 10/12 à 08h00', room: 'S13', mission: 'Bac blanc de philosophie', duration: '4:00:00', type: 'philosophie' },
-            { teacher: 'NDOYE A.', datetime: 'jeudi 11/12 à 14h05', room: 'S14', mission: 'Bac blanc EAF', duration: '4:00:00', type: 'eaf' },
-            { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S12', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '4:00:00', type: 'specialite' },
-            { teacher: 'PIAGGIO F.', datetime: 'jeudi 11/12 à 15h30', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:30:00', type: 'support' }
-        ];
-
-        const roomColumns = ['S9 PRIO / EPS', 'S10', 'S12', 'S13', 'S14'];
-
-        const roomSchedule = [
-            {
-                day: 'Mercredi 10/12',
-                rooms: {
-                    'S9 PRIO / EPS': [
-                        { time: '08h00 - 13h30', teacher: 'BOSSU C.', detail: 'Philosophie', type: 'philosophie' }
-                    ],
-                    'S10': [],
-                    'S12': [
-                        { time: '08h00 - 12h00', teacher: 'GOMIS A.', detail: 'Philosophie', type: 'philosophie' }
-                    ],
-                    'S13': [
-                        { time: '08h00 - 12h00', teacher: 'MOURAIN DIOP F.', detail: 'Philosophie', type: 'philosophie' }
-                    ],
-                    'S14': [
-                        { time: '08h00 - 12h00', teacher: 'MICHON G. M.', detail: 'Philosophie', type: 'philosophie' }
-                    ]
-                }
-            },
-            {
-                day: 'Jeudi 11/12',
-                rooms: {
-                    'S9 PRIO / EPS': [
-                        { label: 'Matin', time: '08h00 - 13h30', teacher: 'FALL B.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
-                        { label: 'Après-midi', time: null }
-                    ],
-                    'S10': [
-                        { label: 'Matin', time: null },
-                        { label: 'Après-midi', time: '14h05 - 18h05', teacher: 'MBOUP N.', detail: 'EAF', highlight: true, type: 'eaf' }
-                    ],
-                    'S12': [
-                        { label: 'Matin', time: '08h00 - 12h00', teacher: 'DAVID V.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
-                        { label: 'Après-midi', time: '13h05 - 18h05', teacher: 'JAÏT L.', detail: 'EAF', type: 'eaf' }
-                    ],
-                    'S13': [
-                        { label: 'Matin', time: '08h00 - 12h00', teacher: 'ANE A.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
-                        { label: 'Après-midi', time: '14h05 - 18h05', teacher: 'MOURAIN DIOP F.', detail: 'EAF', type: 'eaf' }
-                    ],
-                    'S14': [
-                        { label: 'Matin', time: '08h00 - 12h00', teacher: 'MICHON G. M.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
-                        { label: 'Après-midi', time: '14h05 - 18h05', teacher: 'NDOYE A.', detail: 'EAF', type: 'eaf' }
-                    ]
-                }
-            },
-            {
-                day: 'Vendredi 12/12',
-                rooms: {
-                    'S9 PRIO / EPS': [
-                        { time: '08h00 - 13h30', teacher: 'ANE A.', detail: 'Spécialité N°2', type: 'specialite' }
-                    ],
-                    'S10': [],
-                    'S12': [
-                        { time: '08h00 - 12h00', teacher: 'NDOYE A.', detail: 'Spécialité N°2', type: 'specialite' }
-                    ],
-                    'S13': [
-                        { time: '08h00 - 12h00', teacher: 'GOMIS A.', detail: 'Spécialité N°2', type: 'specialite' }
-                    ],
-                    'S14': [
-                        { time: '08h00 - 12h00', teacher: 'MBOUP N.', detail: 'Spécialité N°2', type: 'specialite' }
-                    ]
-                }
-            }
-        ];
-
-        const infoCardsContainer = document.getElementById('info-cards');
-        const teacherScheduleContainer = document.getElementById('teacher-schedule');
-        const roomBody = document.getElementById('room-schedule');
-        const dayScheduleContainer = document.getElementById('day-schedule');
-
-        function renderKeyFiguresCard(figures) {
-            const stats = figures.map(renderKeyFigure).join('');
-            return `
-                <div class="bg-white p-6 rounded-xl shadow-md border border-slate-200">
-                    <div class="flex items-center gap-4 mb-4">
-                        <div class="bg-blue-100 p-3 rounded-full">
-                            <i data-lucide="info" class="text-blue-600"></i>
-                        </div>
-                        <h2 class="text-xl font-semibold">Informations Clés</h2>
-                    </div>
-                    <div class="grid grid-cols-2 gap-y-4 gap-x-2 mt-6 text-center">
-                        ${stats}
-                    </div>
-                </div>
-            `;
-        }
-
-        function renderKeyFigure({ value, unit, label, extra }) {
-            const formattedValue = unit ? `${value}<span class="text-2xl">${unit}</span>` : value;
-            const extraMarkup = extra ? `<p class="text-xs text-slate-400 mt-1">${extra}</p>` : '';
-            return `
-                <div>
-                    <p class="text-4xl font-bold text-blue-600">${formattedValue}</p>
-                    <p class="text-sm text-slate-500 mt-1">${label}</p>
-                    ${extraMarkup}
-                </div>
-            `;
-        }
-
-        function renderAccommodationCard(group) {
-            const studentList = group.students.join(', ');
-            return `
-                <div class="bg-white p-6 rounded-xl shadow-md border border-slate-200">
-                    <div class="flex items-center gap-4 mb-4">
-                        <div class="${group.icon.bg} p-3 rounded-full">
-                            <i data-lucide="${group.icon.name}" class="${group.icon.color}"></i>
-                        </div>
-                        <h2 class="text-xl font-semibold">${group.title}</h2>
-                    </div>
-                    <div class="text-slate-700">
-                        <p class="font-medium mb-2">${group.description}</p>
-                        <p class="text-sm mb-4">${studentList}</p>
-                        <p class="mb-2"><span class="font-semibold">Salles :</span> ${group.rooms}</p>
-                        <div class="mt-4 p-3 ${group.noteClasses} rounded-lg flex items-center text-sm">
-                            <i data-lucide="alert-triangle" class="h-5 w-5 mr-3 flex-shrink-0"></i>
-                            <span>${group.note}</span>
-                        </div>
-                    </div>
-                </div>
-            `;
-        }
-
-        function buildTeacherSchedule(schedule) {
-            const teacherMap = new Map();
-
-            schedule.forEach((entry) => {
-                const teacherName = entry.teacher && entry.teacher.trim() ? entry.teacher.trim() : 'À assigner';
-                if (!teacherMap.has(teacherName)) {
-                    teacherMap.set(teacherName, []);
-                }
-                teacherMap.get(teacherName).push(entry);
+        (() => {
+            const DATA = Object.freeze({
+                typeVariants: Object.freeze({
+                    philosophie: {
+                        label: 'Philosophie',
+                        icon: 'book-open',
+                        badgeClasses: 'bg-slate-200 text-slate-700',
+                        iconColor: 'text-slate-600',
+                        cardBorder: 'border-slate-300',
+                        cardBackground: 'bg-slate-50',
+                        textColor: 'text-slate-700'
+                    },
+                    specialite: {
+                        label: 'Spécialité',
+                        icon: 'calculator',
+                        badgeClasses: 'bg-blue-100 text-blue-700',
+                        iconColor: 'text-blue-600',
+                        cardBorder: 'border-blue-200',
+                        cardBackground: 'bg-blue-50',
+                        textColor: 'text-blue-700'
+                    },
+                    eaf: {
+                        label: 'EAF',
+                        icon: 'pen-line',
+                        badgeClasses: 'bg-violet-100 text-violet-700',
+                        iconColor: 'text-violet-600',
+                        cardBorder: 'border-violet-200',
+                        cardBackground: 'bg-violet-50',
+                        textColor: 'text-violet-700'
+                    },
+                    support: {
+                        label: 'Support',
+                        icon: 'life-buoy',
+                        badgeClasses: 'bg-amber-100 text-amber-700',
+                        iconColor: 'text-amber-600',
+                        cardBorder: 'border-amber-200',
+                        cardBackground: 'bg-amber-50',
+                        textColor: 'text-amber-700'
+                    },
+                    default: {
+                        label: 'Épreuve',
+                        icon: 'calendar-days',
+                        badgeClasses: 'bg-slate-100 text-slate-700',
+                        iconColor: 'text-slate-600',
+                        cardBorder: 'border-slate-200',
+                        cardBackground: 'bg-white',
+                        textColor: 'text-slate-700'
+                    }
+                }),
+                keyFigures: [
+                    { value: '4', label: 'Salles' },
+                    { value: '4', label: 'Épreuves', extra: '(dont 1 EAF 1ère)' },
+                    { value: '4', unit: 'h', label: 'Durée moyenne' },
+                    { value: '64', unit: 'h', label: 'Surveillance' }
+                ],
+                accommodationGroups: [
+                    {
+                        icon: { name: 'users-2', bg: 'bg-green-100', color: 'text-green-600' },
+                        title: 'Terminale',
+                        description: "Liste des élèves avec aménagements d'examen :",
+                        students: ['RISPAL Charlie', 'NDOUR Fatou', 'SOBLOG Oscar', 'FALL CLAMENS Omar', 'ZARB Frédy'],
+                        rooms: '9, 12, 13, 14.',
+                        note: 'Silence requis dans les salles 10 et 11.',
+                        noteClasses: 'bg-amber-100 text-amber-800'
+                    },
+                    {
+                        icon: { name: 'user-check', bg: 'bg-purple-100', color: 'text-purple-600' },
+                        title: 'Première',
+                        description: "Liste des élèves avec aménagements d'examen :",
+                        students: ['JENOUDET Thiméo', 'Owen Thibault', 'SARR Sokhna Faty', 'KERDUDO Zeina'],
+                        rooms: '10, 12, 13, 14.',
+                        note: 'Silence requis dans la salle 11.',
+                        noteClasses: 'bg-amber-100 text-amber-800'
+                    }
+                ],
+                surveillanceSchedule: [
+                    { teacher: 'ANE A.', datetime: 'jeudi 11/12 à 08h00', room: 'S13', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '4:00:00', type: 'specialite' },
+                    { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S9 PRIO / EPS', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '5:30:00', type: 'specialite' },
+                    { teacher: 'BOSSU C.', datetime: 'mercredi 10/12 à 08h00', room: 'S9 PRIO / EPS', mission: 'Bac blanc de philosophie', duration: '5:30:00', type: 'philosophie' },
+                    { teacher: 'DAVID V.', datetime: 'jeudi 11/12 à 08h00', room: 'S12', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '4:00:00', type: 'specialite' },
+                    { teacher: 'FALL B.', datetime: 'jeudi 11/12 à 08h00', room: 'S9 PRIO / EPS', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '5:30:00', type: 'specialite' },
+                    { teacher: '', datetime: 'vendredi 12/12 à 10h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:00:00', type: 'support' },
+                    { teacher: 'GIBUS A.', datetime: 'mercredi 10/12 à 10h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:00:00', type: 'support' },
+                    { teacher: 'GOMIS A.', datetime: 'mercredi 10/12 à 08h00', room: 'S12', mission: 'Bac blanc de philosophie', duration: '4:00:00', type: 'philosophie' },
+                    { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S13', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '4:00:00', type: 'specialite' },
+                    { teacher: 'JAÏT L.', datetime: 'jeudi 11/12 à 08h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:00:00', type: 'support' },
+                    { teacher: '', datetime: 'jeudi 11/12 à 13h05', room: 'S12', mission: 'Bac blanc EAF', duration: '5:00:00', type: 'eaf' },
+                    { teacher: 'MBOUP N.', datetime: 'jeudi 11/12 à 10h00', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '1:30:00', type: 'support' },
+                    { teacher: '', datetime: 'jeudi 11/12 à 14h05', room: 'S10', mission: 'Bac blanc EAF', duration: '4:00:00', type: 'eaf' },
+                    { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S14', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '4:00:00', type: 'specialite' },
+                    { teacher: 'MICHON GUILLAUME M.', datetime: 'jeudi 11/12 à 08h00', room: 'S14', mission: 'Bac blanc : Enseignement de spécialité N°1', duration: '4:00:00', type: 'specialite' },
+                    { teacher: '', datetime: 'mercredi 10/12 à 08h00', room: 'S14', mission: 'Bac blanc de philosophie', duration: '4:00:00', type: 'philosophie' },
+                    { teacher: 'MOURAIN DIOP F.', datetime: 'jeudi 11/12 à 14h05', room: 'S13', mission: 'Bac blanc EAF', duration: '4:00:00', type: 'eaf' },
+                    { teacher: '', datetime: 'mercredi 10/12 à 08h00', room: 'S13', mission: 'Bac blanc de philosophie', duration: '4:00:00', type: 'philosophie' },
+                    { teacher: 'NDOYE A.', datetime: 'jeudi 11/12 à 14h05', room: 'S14', mission: 'Bac blanc EAF', duration: '4:00:00', type: 'eaf' },
+                    { teacher: '', datetime: 'vendredi 12/12 à 08h00', room: 'S12', mission: 'Bac blanc : Enseignement de spécialité N°2', duration: '4:00:00', type: 'specialite' },
+                    { teacher: 'PIAGGIO F.', datetime: 'jeudi 11/12 à 15h30', room: '-', mission: "Remplacer les surveillants du baccalauréat blanc pour qu'ils prennent une pause", duration: '2:30:00', type: 'support' }
+                ],
+                roomColumns: ['S9 PRIO / EPS', 'S10', 'S12', 'S13', 'S14'],
+                roomSchedule: [
+                    {
+                        day: 'Mercredi 10/12',
+                        rooms: {
+                            'S9 PRIO / EPS': [
+                                { time: '08h00 - 13h30', teacher: 'BOSSU C.', detail: 'Philosophie', type: 'philosophie' }
+                            ],
+                            'S10': [],
+                            'S12': [
+                                { time: '08h00 - 12h00', teacher: 'GOMIS A.', detail: 'Philosophie', type: 'philosophie' }
+                            ],
+                            'S13': [
+                                { time: '08h00 - 12h00', teacher: 'MOURAIN DIOP F.', detail: 'Philosophie', type: 'philosophie' }
+                            ],
+                            'S14': [
+                                { time: '08h00 - 12h00', teacher: 'MICHON G. M.', detail: 'Philosophie', type: 'philosophie' }
+                            ]
+                        }
+                    },
+                    {
+                        day: 'Jeudi 11/12',
+                        rooms: {
+                            'S9 PRIO / EPS': [
+                                { label: 'Matin', time: '08h00 - 13h30', teacher: 'FALL B.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
+                                { label: 'Après-midi', time: null }
+                            ],
+                            'S10': [
+                                { label: 'Matin', time: null },
+                                { label: 'Après-midi', time: '14h05 - 18h05', teacher: 'MBOUP N.', detail: 'EAF', highlight: true, type: 'eaf' }
+                            ],
+                            'S12': [
+                                { label: 'Matin', time: '08h00 - 12h00', teacher: 'DAVID V.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
+                                { label: 'Après-midi', time: '13h05 - 18h05', teacher: 'JAÏT L.', detail: 'EAF', type: 'eaf' }
+                            ],
+                            'S13': [
+                                { label: 'Matin', time: '08h00 - 12h00', teacher: 'ANE A.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
+                                { label: 'Après-midi', time: '14h05 - 18h05', teacher: 'MOURAIN DIOP F.', detail: 'EAF', type: 'eaf' }
+                            ],
+                            'S14': [
+                                { label: 'Matin', time: '08h00 - 12h00', teacher: 'MICHON G. M.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
+                                { label: 'Après-midi', time: '14h05 - 18h05', teacher: 'NDOYE A.', detail: 'EAF', type: 'eaf' }
+                            ]
+                        }
+                    },
+                    {
+                        day: 'Vendredi 12/12',
+                        rooms: {
+                            'S9 PRIO / EPS': [
+                                { time: '08h00 - 13h30', teacher: 'ANE A.', detail: 'Spécialité N°2', type: 'specialite' }
+                            ],
+                            'S10': [],
+                            'S12': [
+                                { time: '08h00 - 12h00', teacher: 'NDOYE A.', detail: 'Spécialité N°2', type: 'specialite' }
+                            ],
+                            'S13': [
+                                { time: '08h00 - 12h00', teacher: 'GOMIS A.', detail: 'Spécialité N°2', type: 'specialite' }
+                            ],
+                            'S14': [
+                                { time: '08h00 - 12h00', teacher: 'MBOUP N.', detail: 'Spécialité N°2', type: 'specialite' }
+                            ]
+                        }
+                    }
+                ]
             });
 
-            const teachers = Array.from(teacherMap.entries()).map(([teacher, missions]) => ({ teacher, missions }));
-
-            teachers.sort((a, b) => {
-                if (a.teacher === 'À assigner') {
-                    return 1;
-                }
-                if (b.teacher === 'À assigner') {
-                    return -1;
-                }
-                return a.teacher.localeCompare(b.teacher, 'fr', { sensitivity: 'base' });
+            const SELECTORS = Object.freeze({
+                infoCards: '[data-slot="info-cards"]',
+                teacherSchedule: '[data-slot="teacher-schedule"]',
+                roomSchedule: '[data-slot="room-schedule"]',
+                daySchedule: '[data-slot="day-schedule"]',
+                viewTabs: '[data-view-target]',
+                viewSections: '[data-view-section]',
+                defaultViewButton: '[data-view-default]'
             });
 
-            return teachers;
-        }
+            const icon = (name, classes = '') => `<i data-lucide="${name}" class="${classes}"></i>`;
+            const renderList = (items, renderer) => items.map(renderer).join('');
+            const isNonEmptyString = (value) => typeof value === 'string' && value.trim() !== '';
+            const normalizeTeacherName = (name) => (isNonEmptyString(name) ? name.trim() : 'À assigner');
+            const withFallback = (value, fallback) => (value == null || value === '' ? fallback : value);
 
-        function renderTeacherCard({ teacher, missions }) {
-            const totalSeconds = missions.reduce((sum, mission) => sum + parseDuration(mission.duration), 0);
-            const summary = `${missions.length} mission${missions.length > 1 ? 's' : ''} • ${formatDuration(totalSeconds)}`;
-            const description = teacher === 'À assigner'
-                ? 'Missions en attente d’assignation'
-                : 'Planning confirmé';
-            const badgeClasses = teacher === 'À assigner'
-                ? 'bg-amber-200/80 text-amber-900'
-                : 'bg-slate-200/80 text-slate-600';
-            const badgeIcon = teacher === 'À assigner' ? 'alert-circle' : 'clipboard-list';
-            const missionList = missions
-                .map((mission) => renderTeacherMission(mission))
-                .join('');
+            const groupBy = (items, getKey) => {
+                const map = new Map();
+                items.forEach((item) => {
+                    const key = getKey(item);
+                    if (!map.has(key)) {
+                        map.set(key, []);
+                    }
+                    map.get(key).push(item);
+                });
+                return map;
+            };
 
-            return `
-                <article class="rounded-xl border border-slate-200 bg-slate-50 p-4 shadow-sm transition hover:shadow">
-                    <div class="flex items-start justify-between gap-4">
-                        <div>
-                            <h3 class="text-lg font-semibold text-slate-900">${teacher}</h3>
-                            <p class="text-sm text-slate-500">${summary}</p>
-                        </div>
-                        <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClasses}">
-                            <i data-lucide="${badgeIcon}" class="h-3.5 w-3.5"></i>
-                            ${description}
-                        </span>
-                    </div>
-                    <div class="mt-4 space-y-3">
-                        ${missionList}
-                    </div>
-                </article>
+            const parseDuration = (duration) => {
+                if (!duration) {
+                    return 0;
+                }
+                const [hours = 0, minutes = 0, seconds = 0] = duration.split(':').map(Number);
+                return hours * 3600 + minutes * 60 + seconds;
+            };
+
+            const formatDuration = (totalSeconds) => {
+                const hours = Math.floor(totalSeconds / 3600);
+                const minutes = Math.floor((totalSeconds % 3600) / 60);
+                const parts = [];
+                if (hours) {
+                    parts.push(`${hours}\u202fh`);
+                }
+                if (minutes) {
+                    parts.push(`${minutes}\u202fmin`);
+                }
+                return parts.length ? parts.join(' ') : '0 min';
+            };
+
+            const getTypeConfig = (type) => DATA.typeVariants[type] || DATA.typeVariants.default;
+
+            const renderTypeBadge = (type, { compact = false } = {}) => {
+                const variant = getTypeConfig(type);
+                const textClasses = compact ? 'text-[10px] font-semibold tracking-wide uppercase' : 'text-xs font-semibold';
+                const padding = compact ? 'px-2 py-0.5' : 'px-2.5 py-1';
+                const iconSize = compact ? 'h-3 w-3' : 'h-3.5 w-3.5';
+                return `
+                    <span class="inline-flex items-center gap-1 rounded-full ${padding} ${textClasses} ${variant.badgeClasses}">
+                        ${icon(variant.icon, `${iconSize} ${variant.iconColor}`)}
+                        ${variant.label}
+                    </span>
+                `;
+            };
+
+            const renderTodayBadge = () => `
+                <span class="inline-flex items-center gap-1 rounded-full bg-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-900">
+                    ${icon('sun', 'h-3.5 w-3.5 text-amber-700')}
+                    Aujourd'hui
+                </span>
             `;
-        }
 
-        function renderTeacherMission(mission) {
-            const typeBadge = mission.type ? renderTypeBadge(mission.type, { compact: true }) : '';
-            const isToday = isDatetimeToday(mission.datetime);
-            const datetimeContent = isToday
-                ? `<div class="flex items-center gap-2">${mission.datetime}${renderTodayBadge()}</div>`
-                : mission.datetime;
-            const roomContent = mission.room && mission.room !== '-'
-                ? mission.room
-                : '<span class="italic text-slate-400">Salle à confirmer</span>';
-            const durationValue = mission.duration
-                ? formatDuration(parseDuration(mission.duration))
-                : 'Durée à préciser';
-
-            return `
-                <div class="rounded-lg border border-slate-200 bg-white/80 p-3">
-                    <div class="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
-                        <div class="flex items-center gap-2 text-slate-600">
-                            <i data-lucide="calendar-clock" class="h-4 w-4"></i>
-                            ${datetimeContent}
-                        </div>
-                        ${typeBadge}
+            const renderKeyFigure = ({ value, unit, label, extra }) => {
+                const formattedValue = unit ? `${value}<span class="text-2xl">${unit}</span>` : value;
+                const extraMarkup = extra ? `<p class="mt-1 text-xs text-slate-400">${extra}</p>` : '';
+                return `
+                    <div>
+                        <p class="text-4xl font-bold text-blue-600">${formattedValue}</p>
+                        <p class="mt-1 text-sm text-slate-500">${label}</p>
+                        ${extraMarkup}
                     </div>
-                    <p class="mt-2 text-sm font-semibold text-slate-900">${mission.mission}</p>
-                    <div class="mt-2 flex flex-wrap items-center gap-4 text-xs text-slate-500">
-                        <span class="inline-flex items-center gap-1">
-                            <i data-lucide="map-pin" class="h-3.5 w-3.5"></i>
-                            ${roomContent}
-                        </span>
-                        <span class="inline-flex items-center gap-1">
-                            <i data-lucide="clock-3" class="h-3.5 w-3.5"></i>
-                            ${durationValue}
-                        </span>
+                `;
+            };
+
+            const renderKeyFiguresCard = (figures) => `
+                <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-md">
+                    <div class="mb-4 flex items-center gap-4">
+                        <div class="rounded-full bg-blue-100 p-3">
+                            ${icon('info', 'text-blue-600')}
+                        </div>
+                        <h3 class="text-xl font-semibold">Informations Clés</h3>
+                    </div>
+                    <div class="mt-6 grid grid-cols-2 gap-x-2 gap-y-4 text-center">
+                        ${renderList(figures, renderKeyFigure)}
                     </div>
                 </div>
             `;
-        }
 
-        function parseDuration(duration) {
-            if (!duration) {
-                return 0;
-            }
+            const renderAccommodationCard = (group) => {
+                const students = group.students.join(', ');
+                return `
+                    <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-md">
+                        <div class="mb-4 flex items-center gap-4">
+                            <div class="${group.icon.bg} rounded-full p-3">
+                                ${icon(group.icon.name, group.icon.color)}
+                            </div>
+                            <h3 class="text-xl font-semibold">${group.title}</h3>
+                        </div>
+                        <div class="text-slate-700">
+                            <p class="mb-2 font-medium">${group.description}</p>
+                            <p class="mb-4 text-sm">${students}</p>
+                            <p class="mb-2"><span class="font-semibold">Salles :</span> ${group.rooms}</p>
+                            <div class="mt-4 flex items-center rounded-lg p-3 text-sm ${group.noteClasses}">
+                                ${icon('alert-triangle', 'mr-3 h-5 w-5 flex-shrink-0')}
+                                <span>${group.note}</span>
+                            </div>
+                        </div>
+                    </div>
+                `;
+            };
 
-            const [hours = 0, minutes = 0, seconds = 0] = duration.split(':').map(Number);
-            return (hours * 3600) + (minutes * 60) + seconds;
-        }
+            const buildTeacherSchedule = (schedule) => {
+                const groups = groupBy(schedule, (entry) => normalizeTeacherName(entry.teacher));
+                return Array.from(groups.entries())
+                    .map(([teacher, missions]) => ({ teacher, missions }))
+                    .sort((a, b) => {
+                        if (a.teacher === 'À assigner') {
+                            return 1;
+                        }
+                        if (b.teacher === 'À assigner') {
+                            return -1;
+                        }
+                        return a.teacher.localeCompare(b.teacher, 'fr', { sensitivity: 'base' });
+                    });
+            };
 
-        function formatDuration(totalSeconds) {
-            const hours = Math.floor(totalSeconds / 3600);
-            const minutes = Math.floor((totalSeconds % 3600) / 60);
-            const parts = [];
+            const renderTeacherMission = (mission) => {
+                const typeBadge = mission.type ? renderTypeBadge(mission.type, { compact: true }) : '';
+                const isToday = isDatetimeToday(mission.datetime);
+                const datetimeContent = isToday
+                    ? `<div class="flex items-center gap-2">${mission.datetime}${renderTodayBadge()}</div>`
+                    : mission.datetime;
+                const roomContent = isNonEmptyString(mission.room) && mission.room !== '-'
+                    ? mission.room
+                    : '<span class="italic text-slate-400">Salle à confirmer</span>';
+                const durationValue = mission.duration
+                    ? formatDuration(parseDuration(mission.duration))
+                    : 'Durée à préciser';
 
-            if (hours) {
-                parts.push(`${hours}\u202fh`);
-            }
+                return `
+                    <div class="rounded-lg border border-slate-200 bg-white/80 p-3">
+                        <div class="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
+                            <div class="flex items-center gap-2 text-slate-600">
+                                ${icon('calendar-clock', 'h-4 w-4')}
+                                ${datetimeContent}
+                            </div>
+                            ${typeBadge}
+                        </div>
+                        <p class="mt-2 text-sm font-semibold text-slate-900">${mission.mission}</p>
+                        <div class="mt-2 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                            <span class="inline-flex items-center gap-1">
+                                ${icon('map-pin', 'h-3.5 w-3.5')}
+                                ${roomContent}
+                            </span>
+                            <span class="inline-flex items-center gap-1">
+                                ${icon('clock-3', 'h-3.5 w-3.5')}
+                                ${durationValue}
+                            </span>
+                        </div>
+                    </div>
+                `;
+            };
 
-            if (minutes) {
-                parts.push(`${minutes}\u202fmin`);
-            }
+            const renderTeacherCard = ({ teacher, missions }) => {
+                const totalSeconds = missions.reduce((sum, mission) => sum + parseDuration(mission.duration), 0);
+                const summary = `${missions.length} mission${missions.length > 1 ? 's' : ''} • ${formatDuration(totalSeconds)}`;
+                const description = teacher === 'À assigner'
+                    ? 'Missions en attente d’assignation'
+                    : 'Planning confirmé';
+                const badgeClasses = teacher === 'À assigner'
+                    ? 'bg-amber-200/80 text-amber-900'
+                    : 'bg-slate-200/80 text-slate-600';
+                const badgeIcon = teacher === 'À assigner' ? 'alert-circle' : 'clipboard-list';
 
-            return parts.length > 0 ? parts.join(' ') : '0 min';
-        }
+                return `
+                    <article class="rounded-xl border border-slate-200 bg-slate-50 p-4 shadow-sm transition hover:shadow">
+                        <div class="flex items-start justify-between gap-4">
+                            <div>
+                                <h4 class="text-lg font-semibold text-slate-900">${teacher}</h4>
+                                <p class="text-sm text-slate-500">${summary}</p>
+                            </div>
+                            <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClasses}">
+                                ${icon(badgeIcon, 'h-3.5 w-3.5')}
+                                ${description}
+                            </span>
+                        </div>
+                        <div class="mt-4 space-y-3">
+                            ${renderList(missions, renderTeacherMission)}
+                        </div>
+                    </article>
+                `;
+            };
 
-        function buildDaySchedule(schedule) {
-            return schedule.map(({ day, rooms }) => {
-                const slotMap = new Map();
+            const renderSessionCard = (session) => {
+                const variant = getTypeConfig(session.type);
+                const highlight = getBlockHighlight(session);
+                const classes = [
+                    'flex',
+                    'flex-col',
+                    'items-center',
+                    'gap-2',
+                    'rounded-lg',
+                    'border',
+                    'p-3',
+                    variant.cardBorder,
+                    variant.cardBackground
+                ];
+
+                if (highlight) {
+                    classes.push(highlight.background, highlight.border);
+                }
+
+                if (session.highlight) {
+                    classes.push('ring-2', 'ring-amber-300', 'shadow-sm');
+                }
+
+                const label = session.label ? renderBlockLabel(session, highlight) : '';
+                const typeBadge = session.type ? renderTypeBadge(session.type, { compact: true }) : '';
+                const header = label || typeBadge
+                    ? `<div class="flex w-full items-center ${label && typeBadge ? 'justify-between' : 'justify-start'} gap-2">${label}${typeBadge ? `<div>${typeBadge}</div>` : ''}</div>`
+                    : '';
+
+                const time = session.time
+                    ? `<div class="text-xs font-semibold text-slate-700">${session.time}</div>`
+                    : '<div class="text-xs italic text-slate-400">Horaire à confirmer</div>';
+                const teacher = session.teacher
+                    ? `<div class="text-sm font-semibold ${variant.textColor}">${session.teacher}</div>`
+                    : '<div class="text-xs italic text-slate-400">Surveillant à confirmer</div>';
+                const detail = session.detail ? `<div class="text-xs text-slate-600">${session.detail}</div>` : '';
+
+                return `
+                    <div class="${classes.join(' ')}">
+                        ${header}
+                        <div class="flex flex-col items-center gap-1 text-center">
+                            ${time}
+                            ${teacher}
+                            ${detail}
+                        </div>
+                    </div>
+                `;
+            };
+
+            const renderRoomCell = (sessions = []) => {
+                if (!sessions.length) {
+                    return '<td class="px-6 py-4 text-center"></td>';
+                }
+                const containerClasses = sessions.length > 1
+                    ? 'flex flex-col items-stretch gap-3'
+                    : 'flex items-center justify-center';
+                return `
+                    <td class="px-6 py-4 text-center align-top">
+                        <div class="${containerClasses}">
+                            ${renderList(sessions, renderSessionCard)}
+                        </div>
+                    </td>
+                `;
+            };
+
+            const renderRoomRow = ({ day, rooms }) => {
+                const cells = DATA.roomColumns.map((column) => renderRoomCell(rooms[column] || []));
+                const isToday = isDayLabelToday(day);
+                const rowClasses = ['transition-colors', 'hover:bg-slate-50'];
+                if (isToday) {
+                    rowClasses.push('bg-amber-50/70');
+                }
+                const dayContent = isToday
+                    ? `<div class="flex items-center gap-2">${day}${renderTodayBadge()}</div>`
+                    : day;
+                return `
+                    <tr class="${rowClasses.join(' ')}">
+                        <td class="px-6 py-4 font-medium text-slate-900">${dayContent}</td>
+                        ${cells.join('')}
+                    </tr>
+                `;
+            };
+
+            const renderEmptyState = (message) => `
+                <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
+                    ${message}
+                </div>
+            `;
+
+            const renderBlockLabel = (session, highlight) => {
+                const classes = ['inline-flex', 'items-center', 'gap-1', 'rounded-full', 'px-2', 'py-0.5', 'text-[10px]', 'font-semibold', 'uppercase', 'tracking-wide'];
+                if (highlight) {
+                    classes.push(highlight.badgeBackground, highlight.badgeText);
+                } else {
+                    classes.push('bg-slate-200', 'text-slate-600');
+                }
+                return `<span class="${classes.join(' ')}">${session.label}</span>`;
+            };
+
+            const extractStartHour = (time) => {
+                if (!time) {
+                    return null;
+                }
+                const match = time.match(/(\d{1,2})h/);
+                if (!match) {
+                    return null;
+                }
+                return Number(match[1]);
+            };
+
+            const getBlockHighlight = ({ label, time }) => {
+                const normalizedLabel = withFallback(label, '').toLowerCase();
+                const startHour = extractStartHour(time);
+                if (normalizedLabel.includes('matin') || (startHour !== null && startHour < 12)) {
+                    return {
+                        background: 'bg-sky-50',
+                        border: 'border-sky-200',
+                        badgeBackground: 'bg-sky-200/70',
+                        badgeText: 'text-sky-900'
+                    };
+                }
+                if (normalizedLabel.includes('après') || normalizedLabel.includes('apres') || (startHour !== null && startHour >= 12)) {
+                    return {
+                        background: 'bg-rose-50',
+                        border: 'border-rose-200',
+                        badgeBackground: 'bg-rose-200/70',
+                        badgeText: 'text-rose-900'
+                    };
+                }
+                return null;
+            };
+
+            const buildDaySchedule = (schedule) => schedule.map(({ day, rooms }) => {
                 const slots = [];
-
+                const slotMap = new Map();
                 Object.entries(rooms).forEach(([room, sessions]) => {
                     sessions.forEach((session) => {
                         const key = session.time || session.label || 'Horaire à confirmer';
-
                         if (!slotMap.has(key)) {
-                            const slot = {
+                            slotMap.set(key, {
                                 key,
                                 time: session.time || null,
                                 label: session.label || null,
                                 entries: []
-                            };
-                            slotMap.set(key, slot);
-                            slots.push(slot);
+                            });
+                            slots.push(slotMap.get(key));
                         }
-
                         slotMap.get(key).entries.push({
                             room,
                             teacher: session.teacher,
@@ -472,355 +620,187 @@
                         });
                     });
                 });
-
                 slots.sort((a, b) => {
                     const hourA = extractStartHour(a.time);
                     const hourB = extractStartHour(b.time);
-
                     if (hourA !== null && hourB !== null) {
                         return hourA - hourB;
                     }
-
                     if (hourA !== null) {
                         return -1;
                     }
-
                     if (hourB !== null) {
                         return 1;
                     }
-
-                    return (a.label || '').localeCompare(b.label || '', 'fr', { sensitivity: 'base' });
+                    return withFallback(a.label, '').localeCompare(withFallback(b.label, ''), 'fr', { sensitivity: 'base' });
                 });
-
                 return { day, slots };
             });
-        }
 
-        function renderDayCard({ day, slots }) {
-            const isToday = isDayLabelToday(day);
-            const badge = isToday ? renderTodayBadge() : '';
-            const content = slots.length
-                ? slots.map((slot) => renderDaySlot(slot)).join('')
-                : renderEmptyState('Aucun créneau planifié pour cette journée.');
-
-            return `
-                <article class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                    <div class="flex flex-wrap items-center justify-between gap-2">
-                        <h3 class="text-lg font-semibold text-slate-900">${day}</h3>
-                        ${badge}
-                    </div>
-                    <div class="mt-4 space-y-4">
-                        ${content}
-                    </div>
-                </article>
-            `;
-        }
-
-        function renderDaySlot(slot) {
-            const highlight = getBlockHighlight(slot);
-            const slotClasses = ['rounded-lg', 'border', 'border-slate-200', 'bg-slate-50', 'p-3'];
-
-            if (highlight) {
-                slotClasses.push(highlight.background, highlight.border);
-            }
-
-            const label = slot.label && (!slot.time || slot.label !== slot.time)
-                ? renderBlockLabel(slot, highlight)
-                : '';
-
-            const entries = slot.entries.length
-                ? slot.entries.map((entry) => renderDaySession(entry)).join('')
-                : `<p class="text-xs italic text-slate-400">Aucune surveillance prévue.</p>`;
-
-            return `
-                <div class="${slotClasses.join(' ')}">
-                    <div class="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
-                        <div class="flex items-center gap-2">
-                            <i data-lucide="clock" class="h-4 w-4 text-slate-500"></i>
-                            ${slot.time || slot.label || 'Horaire à confirmer'}
+            const renderDaySession = (entry) => {
+                const badge = entry.type ? renderTypeBadge(entry.type, { compact: true }) : '';
+                const teacherContent = entry.teacher
+                    ? `<span class="font-semibold text-slate-900">${entry.teacher}</span>`
+                    : '<span class="italic text-slate-400">Surveillant à confirmer</span>';
+                const detailContent = entry.detail ? `<p class="text-xs text-slate-500">${entry.detail}</p>` : '';
+                const classes = ['rounded-lg', 'border', 'border-slate-200', 'bg-white', 'p-3', 'shadow-sm'];
+                if (entry.highlight) {
+                    classes.push('ring-2', 'ring-amber-300/70');
+                }
+                return `
+                    <div class="${classes.join(' ')}">
+                        <div class="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            <span>${entry.room}</span>
+                            ${badge}
                         </div>
-                        ${label}
+                        <div class="mt-2 text-sm text-slate-700">
+                            ${teacherContent}
+                        </div>
+                        ${detailContent}
                     </div>
-                    <div class="mt-3 grid gap-3 md:grid-cols-2">
-                        ${entries}
-                    </div>
-                </div>
-            `;
-        }
-
-        function renderDaySession(entry) {
-            const badge = entry.type ? renderTypeBadge(entry.type, { compact: true }) : '';
-            const teacherContent = entry.teacher
-                ? `<span class="font-semibold text-slate-900">${entry.teacher}</span>`
-                : '<span class="italic text-slate-400">Surveillant à confirmer</span>';
-            const detailContent = entry.detail ? `<p class="text-xs text-slate-500">${entry.detail}</p>` : '';
-            const wrapperClasses = ['rounded-lg', 'border', 'border-slate-200', 'bg-white', 'p-3', 'shadow-sm'];
-
-            if (entry.highlight) {
-                wrapperClasses.push('ring-2', 'ring-amber-300/70');
-            }
-
-            return `
-                <div class="${wrapperClasses.join(' ')}">
-                    <div class="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                        <span>${entry.room}</span>
-                        ${badge}
-                    </div>
-                    <div class="mt-2 text-sm text-slate-700">
-                        ${teacherContent}
-                    </div>
-                    ${detailContent}
-                </div>
-            `;
-        }
-
-        function renderEmptyState(message) {
-            return `
-                <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
-                    ${message}
-                </div>
-            `;
-        }
-
-        function getBlockHighlight({ label, time }) {
-            const normalizedLabel = (label || '').toLowerCase();
-            const startHour = extractStartHour(time);
-
-            if (normalizedLabel.includes('matin') || (startHour !== null && startHour < 12)) {
-                return {
-                    background: 'bg-sky-50',
-                    border: 'border-sky-200',
-                    badgeBackground: 'bg-sky-200/70',
-                    badgeText: 'text-sky-900'
-                };
-            }
-
-            if (normalizedLabel.includes('après') || normalizedLabel.includes('apres') || (startHour !== null && startHour >= 12)) {
-                return {
-                    background: 'bg-rose-50',
-                    border: 'border-rose-200',
-                    badgeBackground: 'bg-rose-200/70',
-                    badgeText: 'text-rose-900'
-                };
-            }
-
-            return null;
-        }
-
-        function renderBlockLabel(session, highlight) {
-            const classes = ['inline-flex', 'items-center', 'gap-1', 'rounded-full', 'px-2', 'py-0.5', 'text-[10px]', 'font-semibold', 'uppercase', 'tracking-wide'];
-
-            if (highlight) {
-                classes.push(highlight.badgeBackground, highlight.badgeText);
-            } else {
-                classes.push('bg-slate-200', 'text-slate-600');
-            }
-
-            return `<span class="${classes.join(' ')}">${session.label}</span>`;
-        }
-
-        function extractStartHour(time) {
-            if (!time) {
-                return null;
-            }
-
-            const match = time.match(/(\d{1,2})h/);
-            if (!match) {
-                return null;
-            }
-
-            return Number(match[1]);
-        }
-
-        function setupViewTabs() {
-            const buttons = document.querySelectorAll('[data-view-target]');
-            const sections = document.querySelectorAll('[data-view-section]');
-
-            if (!buttons.length || !sections.length) {
-                return;
-            }
-
-            const setActiveView = (view) => {
-                sections.forEach((section) => {
-                    section.classList.toggle('hidden', section.dataset.viewSection !== view);
-                });
-
-                buttons.forEach((button) => {
-                    const isActive = button.dataset.viewTarget === view;
-                    button.setAttribute('aria-pressed', String(isActive));
-                    if (isActive) {
-                        button.classList.remove('bg-slate-100', 'text-slate-600');
-                        button.classList.add('bg-blue-600', 'text-white', 'shadow');
-                    } else {
-                        button.classList.add('bg-slate-100', 'text-slate-600');
-                        button.classList.remove('bg-blue-600', 'text-white', 'shadow');
-                    }
-                });
+                `;
             };
 
-            buttons.forEach((button) => {
-                button.addEventListener('click', () => setActiveView(button.dataset.viewTarget));
-            });
-
-            const defaultButton = document.querySelector('[data-view-default]');
-            const defaultView = defaultButton ? defaultButton.dataset.viewTarget : buttons[0].dataset.viewTarget;
-            setActiveView(defaultView);
-        }
-
-        function renderRoomRow({ day, rooms }) {
-            const cells = roomColumns.map((column) => renderRoomCell(rooms[column] || []));
-            const isToday = isDayLabelToday(day);
-            const rowClasses = ['transition-colors', 'hover:bg-slate-50'];
-
-            if (isToday) {
-                rowClasses.push('bg-amber-50/70');
-            }
-
-            const dayContent = isToday
-                ? `<div class="flex items-center gap-2">${day}${renderTodayBadge()}</div>`
-                : day;
-
-            return `
-                <tr class="${rowClasses.join(' ')}">
-                    <td class="px-6 py-4 font-medium text-slate-900">${dayContent}</td>
-                    ${cells.join('')}
-                </tr>
-            `;
-        }
-
-        function renderRoomCell(sessions) {
-            if (!sessions || sessions.length === 0) {
-                return '<td class="px-6 py-4 text-center"></td>';
-            }
-
-            const sessionCards = sessions.map((session) => renderSessionCard(session)).join('');
-            const containerClasses = sessions.length > 1
-                ? 'flex flex-col gap-3 items-stretch'
-                : 'flex justify-center items-center';
-
-            return `
-                <td class="px-6 py-4 text-center align-top">
-                    <div class="${containerClasses}">
-                        ${sessionCards}
+            const renderDaySlot = (slot) => {
+                const highlight = getBlockHighlight(slot);
+                const classes = ['rounded-lg', 'border', 'border-slate-200', 'bg-slate-50', 'p-3'];
+                if (highlight) {
+                    classes.push(highlight.background, highlight.border);
+                }
+                const label = slot.label && (!slot.time || slot.label !== slot.time)
+                    ? renderBlockLabel(slot, highlight)
+                    : '';
+                const entries = slot.entries.length
+                    ? renderList(slot.entries, renderDaySession)
+                    : '<p class="text-xs italic text-slate-400">Aucune surveillance prévue.</p>';
+                return `
+                    <div class="${classes.join(' ')}">
+                        <div class="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
+                            <div class="flex items-center gap-2">
+                                ${icon('clock', 'h-4 w-4 text-slate-500')}
+                                ${slot.time || slot.label || 'Horaire à confirmer'}
+                            </div>
+                            ${label}
+                        </div>
+                        <div class="mt-3 grid gap-3 md:grid-cols-2">
+                            ${entries}
+                        </div>
                     </div>
-                </td>
-            `;
-        }
+                `;
+            };
 
-        function renderSessionCard(session) {
-            const typeConfig = getTypeConfig(session.type);
-            const blockHighlight = getBlockHighlight(session);
-            const baseClasses = ['rounded-lg', 'border', 'p-3', 'flex', 'flex-col', 'gap-2', 'items-center', typeConfig.cardBorder, typeConfig.cardBackground];
+            const renderDayCard = ({ day, slots }) => {
+                const isToday = isDayLabelToday(day);
+                const badge = isToday ? renderTodayBadge() : '';
+                const content = slots.length
+                    ? renderList(slots, renderDaySlot)
+                    : renderEmptyState('Aucun créneau planifié pour cette journée.');
+                return `
+                    <article class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <h4 class="text-lg font-semibold text-slate-900">${day}</h4>
+                            ${badge}
+                        </div>
+                        <div class="mt-4 space-y-4">
+                            ${content}
+                        </div>
+                    </article>
+                `;
+            };
 
-            if (blockHighlight) {
-                baseClasses.push(blockHighlight.background, blockHighlight.border);
-            }
+            const parseDayParts = (label) => {
+                const match = label.match(/(\d{1,2})\/(\d{1,2})/);
+                if (!match) {
+                    return null;
+                }
+                return { day: Number(match[1]), month: Number(match[2]) };
+            };
 
-            if (session.highlight) {
-                baseClasses.push('ring-2', 'ring-amber-300', 'shadow-sm');
-            }
+            const parseDatetimeParts = (datetime) => parseDayParts(datetime);
 
-            const label = session.label ? renderBlockLabel(session, blockHighlight) : '';
+            const isTodayFromParts = (parts) => {
+                if (!parts) {
+                    return false;
+                }
+                const now = new Date();
+                return now.getDate() === parts.day && now.getMonth() + 1 === parts.month;
+            };
 
-            const typeBadge = session.type ? renderTypeBadge(session.type, { compact: true }) : '';
-            const header = label || typeBadge
-                ? `<div class="flex w-full items-center ${label && typeBadge ? 'justify-between' : 'justify-start'} gap-2">${label}${typeBadge ? `<div>${typeBadge}</div>` : ''}</div>`
-                : '';
+            const isDayLabelToday = (label) => isTodayFromParts(parseDayParts(label));
+            const isDatetimeToday = (datetime) => isTodayFromParts(parseDatetimeParts(datetime));
 
-            const time = session.time
-                ? `<div class="text-xs font-semibold text-slate-700">${session.time}</div>`
-                : '<div class="text-xs text-slate-400 italic">Horaire à confirmer</div>';
-            const teacher = session.teacher
-                ? `<div class="text-sm font-semibold ${typeConfig.textColor}">${session.teacher}</div>`
-                : '<div class="text-xs italic text-slate-400">Surveillant à confirmer</div>';
-            const detail = session.detail ? `<div class="text-xs text-slate-600">${session.detail}</div>` : '';
+            const setupViewTabs = () => {
+                const buttons = Array.from(document.querySelectorAll(SELECTORS.viewTabs));
+                const sections = Array.from(document.querySelectorAll(SELECTORS.viewSections));
+                if (!buttons.length || !sections.length) {
+                    return;
+                }
+                const setActiveView = (view) => {
+                    sections.forEach((section) => {
+                        const isActive = section.dataset.viewSection === view;
+                        section.classList.toggle('hidden', !isActive);
+                        section.setAttribute('aria-hidden', String(!isActive));
+                        section.setAttribute('tabindex', isActive ? '0' : '-1');
+                    });
+                    buttons.forEach((button) => {
+                        const isActive = button.dataset.viewTarget === view;
+                        button.setAttribute('aria-pressed', String(isActive));
+                        button.setAttribute('aria-selected', String(isActive));
+                        if (isActive) {
+                            button.classList.remove('bg-slate-100', 'text-slate-600');
+                            button.classList.add('bg-blue-600', 'text-white', 'shadow');
+                        } else {
+                            button.classList.add('bg-slate-100', 'text-slate-600');
+                            button.classList.remove('bg-blue-600', 'text-white', 'shadow');
+                        }
+                    });
+                };
+                buttons.forEach((button) => {
+                    button.addEventListener('click', () => setActiveView(button.dataset.viewTarget));
+                });
+                const defaultButton = document.querySelector(SELECTORS.defaultViewButton) || buttons[0];
+                if (defaultButton) {
+                    setActiveView(defaultButton.dataset.viewTarget);
+                }
+            };
 
-            return `
-                <div class="${baseClasses.join(' ')}">
-                    ${header}
-                    <div class="flex flex-col items-center gap-1 text-center">
-                        ${time}
-                        ${teacher}
-                        ${detail}
-                    </div>
-                </div>
-            `;
-        }
+            const renderDashboard = () => {
+                const infoCardsContainer = document.querySelector(SELECTORS.infoCards);
+                const teacherScheduleContainer = document.querySelector(SELECTORS.teacherSchedule);
+                const roomScheduleBody = document.querySelector(SELECTORS.roomSchedule);
+                const dayScheduleContainer = document.querySelector(SELECTORS.daySchedule);
 
-        function getTypeConfig(type) {
-            return TYPE_CONFIG[type] || TYPE_CONFIG.default;
-        }
+                if (infoCardsContainer) {
+                    const cardsMarkup = [renderKeyFiguresCard(DATA.keyFigures), ...DATA.accommodationGroups.map(renderAccommodationCard)];
+                    infoCardsContainer.innerHTML = renderList(cardsMarkup, (card) => card);
+                }
 
-        function renderTypeBadge(type, { compact = false } = {}) {
-            const typeConfig = getTypeConfig(type);
-            const textClasses = compact ? 'text-[10px] font-semibold tracking-wide uppercase' : 'text-xs font-semibold';
-            const padding = compact ? 'px-2 py-0.5' : 'px-2.5 py-1';
-            const iconSize = compact ? 'h-3 w-3' : 'h-3.5 w-3.5';
+                if (teacherScheduleContainer) {
+                    const teacherSchedule = buildTeacherSchedule(DATA.surveillanceSchedule);
+                    teacherScheduleContainer.innerHTML = teacherSchedule.length
+                        ? renderList(teacherSchedule, renderTeacherCard)
+                        : renderEmptyState('Aucune mission de surveillance enregistrée pour le moment.');
+                }
 
-            return `
-                <span class="inline-flex items-center gap-1 rounded-full ${padding} ${textClasses} ${typeConfig.badgeClasses}">
-                    <i data-lucide="${typeConfig.icon}" class="${iconSize} ${typeConfig.iconColor}"></i>
-                    ${typeConfig.label}
-                </span>
-            `;
-        }
+                if (roomScheduleBody) {
+                    roomScheduleBody.innerHTML = renderList(DATA.roomSchedule, renderRoomRow);
+                }
 
-        function parseDayParts(label) {
-            const match = label.match(/(\d{1,2})\/(\d{1,2})/);
-            if (!match) {
-                return null;
-            }
+                if (dayScheduleContainer) {
+                    const daySchedule = buildDaySchedule(DATA.roomSchedule);
+                    dayScheduleContainer.innerHTML = daySchedule.length
+                        ? renderList(daySchedule, renderDayCard)
+                        : renderEmptyState('Aucune journée planifiée.');
+                }
 
-            return { day: Number(match[1]), month: Number(match[2]) };
-        }
+                setupViewTabs();
+                if (window.lucide && typeof window.lucide.createIcons === 'function') {
+                    window.lucide.createIcons();
+                }
+            };
 
-        function parseDatetimeParts(datetime) {
-            return parseDayParts(datetime);
-        }
-
-        function isTodayFromParts(parts) {
-            if (!parts) {
-                return false;
-            }
-
-            const now = new Date();
-            return now.getDate() === parts.day && (now.getMonth() + 1) === parts.month;
-        }
-
-        function isDayLabelToday(label) {
-            return isTodayFromParts(parseDayParts(label));
-        }
-
-        function isDatetimeToday(datetime) {
-            return isTodayFromParts(parseDatetimeParts(datetime));
-        }
-
-        function renderTodayBadge() {
-            return `
-                <span class="inline-flex items-center gap-1 rounded-full bg-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-900">
-                    <i data-lucide="sun" class="h-3.5 w-3.5 text-amber-700"></i>
-                    Aujourd'hui
-                </span>
-            `;
-        }
-
-        document.addEventListener('DOMContentLoaded', () => {
-            const cardsMarkup = [renderKeyFiguresCard(keyFigures), ...accommodationGroups.map(renderAccommodationCard)];
-            const teacherSchedule = buildTeacherSchedule(surveillanceSchedule);
-            const daySchedule = buildDaySchedule(roomSchedule);
-
-            infoCardsContainer.innerHTML = cardsMarkup.join('');
-            teacherScheduleContainer.innerHTML = teacherSchedule.length
-                ? teacherSchedule.map((item) => renderTeacherCard(item)).join('')
-                : renderEmptyState('Aucune mission de surveillance enregistrée pour le moment.');
-            roomBody.innerHTML = roomSchedule.map((row) => renderRoomRow(row)).join('');
-            dayScheduleContainer.innerHTML = daySchedule.length
-                ? daySchedule.map((item) => renderDayCard(item)).join('')
-                : renderEmptyState('Aucune journée planifiée.');
-
-            setupViewTabs();
-            lucide.createIcons();
-        });
+            document.addEventListener('DOMContentLoaded', renderDashboard);
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reorganized the dashboard markup into semantic sections and data-slot anchors for rendering
- factored the client-side script into reusable helpers that generate cards, schedules, and day views from shared data
- improved tab management with accessible attributes and centralized configuration constants

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dad7a9a0ac8331a8a3afca73aa6a66