### PR TITLE
Fix room view alignment for Mboup session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,11 @@ export default function App() {
       <div className="container mx-auto space-y-8 p-4 sm:p-6 lg:p-8">
         <Header />
         <Hero />
-        <ExamDashboard />
-        <SurveillanceTable />
-        <RoomsStatus />
-        <Announcements />
+        <ExamDashboard>
+          <SurveillanceTable />
+          <RoomsStatus />
+          <Announcements />
+        </ExamDashboard>
         <Footer />
       </div>
     </div>

--- a/src/sections/ExamDashboard.tsx
+++ b/src/sections/ExamDashboard.tsx
@@ -1,10 +1,14 @@
-import { useCallback, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 
 import { dashboardTabs } from "../lib/dashboard-data";
 import { DashboardContext } from "../lib/dashboard-context";
 import type { DashboardView } from "../lib/dashboard-utils";
 
-export default function ExamDashboard() {
+interface ExamDashboardProps {
+  children?: ReactNode;
+}
+
+export default function ExamDashboard({ children }: ExamDashboardProps) {
   const [activeView, setActiveView] = useState<DashboardView>("teacher");
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
 
@@ -22,11 +26,11 @@ export default function ExamDashboard() {
   );
 
   return (
-    <section aria-labelledby="views-title" className="space-y-6">
-      <h2 id="views-title" className="sr-only">
-        Affichage des plannings
-      </h2>
-      <DashboardContext.Provider value={contextValue}>
+    <DashboardContext.Provider value={contextValue}>
+      <section aria-labelledby="views-title" className="space-y-6">
+        <h2 id="views-title" className="sr-only">
+          Affichage des plannings
+        </h2>
         <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-md">
           <div
             className="flex flex-wrap items-center gap-2 border-b border-slate-200 pb-4"
@@ -59,7 +63,8 @@ export default function ExamDashboard() {
           </div>
           <div className="mt-6 space-y-10" ref={setContainerRef} />
         </div>
-      </DashboardContext.Provider>
-    </section>
+      </section>
+      {children}
+    </DashboardContext.Provider>
   );
 }

--- a/src/sections/RoomsStatus.tsx
+++ b/src/sections/RoomsStatus.tsx
@@ -106,11 +106,15 @@ function RoomCell({ sessions }: { sessions: RoomSession[] }) {
   if (!sessions.length) {
     return <TableCell className="text-center" />;
   }
-  const containerClasses =
-    sessions.length > 1 ? "flex flex-col items-stretch gap-3" : "flex items-center justify-center";
+  const containerClasses = ["flex", "flex-col", "gap-3", "justify-start"];
+  if (sessions.length > 1) {
+    containerClasses.push("items-stretch");
+  } else {
+    containerClasses.push("items-center");
+  }
   return (
     <TableCell className="text-center align-top">
-      <div className={containerClasses}>
+      <div className={containerClasses.join(" ")}>
         {sessions.map((session, index) => (
           <SessionCard key={index} session={session} />
         ))}


### PR DESCRIPTION
## Summary
- allow `ExamDashboard` to wrap view components so the dashboard context is shared across the portal sections
- nest the teacher, room, and day views within the dashboard component
- adjust the room view layout so single-session cells align to the top like the afternoon block for Mboup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf24a2c28833193d1505de99806d6