### PR TITLE
Adjust header logo styling

### DIFF
--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -5,7 +5,7 @@ export default function Header() {
         <div className="flex items-center gap-4">
           <img
             alt="Logo du Lycée Franco-Japonais de Paris"
-            className="h-16 w-16 flex-shrink-0 rounded-full border border-slate-200 bg-white object-cover shadow-sm"
+            className="h-16 flex-shrink-0 rounded-lg border border-slate-200 bg-white object-contain shadow-sm"
             src="https://i.imgur.com/0YmGlXO.png"
           />
           <div>


### PR DESCRIPTION
## Summary
- update header logo styling to show the full rectangular image without cropping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafc67a78483318fad113f8b8bb442