### PR TITLE
Align afternoon session cards in room schedule view

### DIFF
--- a/src/sections/RoomsStatus.tsx
+++ b/src/sections/RoomsStatus.tsx
@@ -162,15 +162,23 @@ function RoomCell({ sessions }: { sessions: RoomSession[] }) {
     }
   }
 
+  const shouldReserveMorningSpace =
+    !hasMultipleSessions && singleSession && isAfternoonSession(singleSession);
+
   const containerClasses = cn(
     "flex h-full flex-col",
-    hasMultipleSessions ? "items-stretch gap-3" : "items-center",
+    hasMultipleSessions || shouldReserveMorningSpace ? "items-stretch gap-3" : "items-center",
     verticalAlignment,
   );
 
   return (
     <TableCell className="text-center align-top">
       <div className={containerClasses}>
+        {shouldReserveMorningSpace ? (
+          <div aria-hidden className="invisible">
+            <SessionCard session={singleSession} />
+          </div>
+        ) : null}
         {sessions.map((session, index) => (
           <SessionCard key={index} session={session} />
         ))}

--- a/src/sections/RoomsStatus.tsx
+++ b/src/sections/RoomsStatus.tsx
@@ -102,12 +102,72 @@ function SessionCard({ session }: { session: RoomSession }) {
   );
 }
 
+const normalizeLabel = (value?: string): string => value?.toLowerCase() ?? "";
+
+const extractStartHour = (time?: string): number | null => {
+  if (!time) {
+    return null;
+  }
+  const match = time.match(/(\d{1,2})h/);
+  if (!match) {
+    return null;
+  }
+  return Number.parseInt(match[1], 10);
+};
+
+const isAfternoonSession = (session?: RoomSession): boolean => {
+  if (!session) {
+    return false;
+  }
+  const label = normalizeLabel(session.label);
+  if (label.includes("après") || label.includes("apres")) {
+    return true;
+  }
+  if (label.includes("matin")) {
+    return false;
+  }
+  const startHour = extractStartHour(session.time);
+  return startHour !== null && startHour >= 12;
+};
+
+const isMorningSession = (session?: RoomSession): boolean => {
+  if (!session) {
+    return false;
+  }
+  const label = normalizeLabel(session.label);
+  if (label.includes("matin")) {
+    return true;
+  }
+  if (label.includes("après") || label.includes("apres")) {
+    return false;
+  }
+  const startHour = extractStartHour(session.time);
+  return startHour !== null && startHour < 12;
+};
+
 function RoomCell({ sessions }: { sessions: RoomSession[] }) {
   if (!sessions.length) {
     return <TableCell className="text-center" />;
   }
-  const containerClasses =
-    sessions.length > 1 ? "flex flex-col items-stretch gap-3" : "flex items-center justify-center";
+
+  const hasMultipleSessions = sessions.length > 1;
+  const [singleSession] = sessions;
+
+  let verticalAlignment = "justify-center";
+  if (!hasMultipleSessions && singleSession) {
+    if (isAfternoonSession(singleSession)) {
+      verticalAlignment = "justify-end";
+    } else if (isMorningSession(singleSession)) {
+      verticalAlignment = "justify-start";
+    }
+  }
+
+  const containerClasses = cn(
+    "flex h-full flex-col",
+    hasMultipleSessions ? "items-stretch gap-3" : "items-center",
+    verticalAlignment,
+  );
+
   return (
     <TableCell className="text-center align-top">
       <div className={containerClasses}>


### PR DESCRIPTION
## Summary
- adjust the room schedule cell layout so single afternoon entries sit at the bottom of the column
- detect morning versus afternoon slots to keep single-session rooms aligned with their respective block

## Testing
- npm run build *(fails: vite command not found in environment)*
- npm install *(fails: dependency conflict between eslint and @typescript-eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_68dafcd205c88331962cf62167b79a9c