### PR TITLE
Add PDF exports for convocation generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bac_blanc_2512",
       "version": "0.0.0",
       "dependencies": {
+        "jspdf": "^3.0.3",
         "lucide-react": "^0.424.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -296,6 +297,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1466,12 +1476,25 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
@@ -1493,6 +1516,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -2031,6 +2061,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.9.tgz",
@@ -2202,6 +2242,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2301,6 +2361,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2314,6 +2386,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2489,6 +2571,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -3125,6 +3217,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3134,6 +3237,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3578,6 +3687,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3629,6 +3752,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -4169,6 +4298,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -4608,6 +4754,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4681,6 +4833,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4962,6 +5121,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5050,6 +5219,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -5108,6 +5284,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -5434,6 +5620,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -5712,6 +5908,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -5769,6 +5975,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -6005,6 +6221,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.20",

--- a/package.json
+++ b/package.json
@@ -10,23 +10,24 @@
     "lint": "eslint . --ext ts,tsx --max-warnings 0"
   },
   "dependencies": {
+    "jspdf": "^3.0.3",
     "lucide-react": "^0.424.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
-    "devDependencies": {
-      "@types/node": "^20.16.5",
-      "@typescript-eslint/eslint-plugin": "^7.18.0",
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@types/react": "^18.3.6",
+    "@types/react-dom": "^18.3.2",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
-    "@types/react": "^18.3.6",
-    "@types/react-dom": "^18.3.2",
-    "@vitejs/plugin-react": "^4.3.1",
-    "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.4.5",

--- a/src/components/ProviseurSignature.tsx
+++ b/src/components/ProviseurSignature.tsx
@@ -1,0 +1,36 @@
+export default function ProviseurSignature() {
+  return (
+    <div className="mt-8 space-y-2 text-sm text-slate-600">
+      <p className="font-medium text-slate-700">Le Proviseur</p>
+      <svg
+        className="h-16 w-40 text-slate-500"
+        viewBox="0 0 200 80"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10 60 C 30 20, 60 20, 75 55 C 85 75, 105 40, 120 50 C 135 60, 150 45, 170 55"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M32 48 C 38 42, 45 42, 52 52"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M132 52 C 138 42, 150 40, 158 50"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <p className="text-xs uppercase tracking-wide text-slate-400">Signature</p>
+    </div>
+  );
+}

--- a/src/lib/convocation-pdf.ts
+++ b/src/lib/convocation-pdf.ts
@@ -1,0 +1,243 @@
+import { jsPDF } from "jspdf";
+
+import {
+  teacherDirectoryByShortName,
+  typeVariants,
+} from "./dashboard-data";
+import {
+  formatDuration,
+  parseDuration,
+  type TeacherScheduleGroup,
+} from "./dashboard-utils";
+
+const PAGE_MARGIN_X = 20;
+const PAGE_MARGIN_Y = 20;
+const SUMMARY_BOX_HEIGHT = 20;
+
+function getTeacherDetails(group: TeacherScheduleGroup) {
+  const teacherEntry = teacherDirectoryByShortName[group.teacher];
+  const salutation = teacherEntry?.civility ?? "Madame, Monsieur";
+  const teacherDisplayName = teacherEntry
+    ? `${teacherEntry.firstName} ${teacherEntry.lastName}`
+    : group.teacher;
+  const invitationSentence = teacherEntry
+    ? teacherEntry.gender === "female"
+      ? "Vous êtes conviée"
+      : "Vous êtes convié"
+    : "Vous êtes convié(e)";
+
+  return {
+    salutation,
+    teacherDisplayName,
+    invitationSentence,
+  };
+}
+
+function addHeader(pdf: jsPDF) {
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(16);
+  pdf.text("Convocation de surveillance", PAGE_MARGIN_X, PAGE_MARGIN_Y);
+}
+
+function addIntro(
+  pdf: jsPDF,
+  group: TeacherScheduleGroup,
+  startY: number,
+): number {
+  const { salutation, teacherDisplayName, invitationSentence } =
+    getTeacherDetails(group);
+
+  pdf.setFont("helvetica", "normal");
+  pdf.setFontSize(12);
+
+  const introLines = pdf.splitTextToSize(
+    `${salutation} ${teacherDisplayName},\n${invitationSentence} à assurer les surveillances suivantes dans le cadre du baccalauréat blanc. Retrouvez ci-dessous les horaires, salles, épreuves et fonctions associées à chaque mission.`,
+    pdf.internal.pageSize.getWidth() - PAGE_MARGIN_X * 2,
+  );
+  pdf.text(introLines, PAGE_MARGIN_X, startY + 8);
+
+  return startY + 8 + introLines.length * 6 + 4;
+}
+
+function measureMissionHeight(
+  pdf: jsPDF,
+  mission: TeacherScheduleGroup["missions"][number],
+): number {
+  const availableWidth = pdf.internal.pageSize.getWidth() - PAGE_MARGIN_X * 2;
+  const missionLabelLines = pdf.splitTextToSize(`Épreuve / fonction : ${mission.mission}`, availableWidth);
+  const roomLabel = mission.room && mission.room.trim() !== "-" ? mission.room : "Salle à confirmer";
+  const roomLines = pdf.splitTextToSize(`Salle : ${roomLabel}`, availableWidth);
+
+  return 6 + missionLabelLines.length * 5 + roomLines.length * 5 + 5 + 5 + 8 + 8;
+}
+
+function addMission(
+  pdf: jsPDF,
+  mission: TeacherScheduleGroup["missions"][number],
+  cursorY: number,
+): number {
+  const width = pdf.internal.pageSize.getWidth();
+  const availableWidth = width - PAGE_MARGIN_X * 2;
+  const roomLabel = mission.room && mission.room.trim() !== "-" ? mission.room : "Salle à confirmer";
+  const typeLabel = typeVariants[mission.type ?? ""]?.label ?? typeVariants.default.label;
+  const duration = mission.duration ? formatDuration(parseDuration(mission.duration)) : "Durée à préciser";
+
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(12);
+  pdf.text(mission.datetime, PAGE_MARGIN_X, cursorY);
+  cursorY += 6;
+
+  pdf.setFont("helvetica", "normal");
+  const missionLabelLines = pdf.splitTextToSize(`Épreuve / fonction : ${mission.mission}`, availableWidth);
+  missionLabelLines.forEach((line) => {
+    pdf.text(line, PAGE_MARGIN_X + 2, cursorY);
+    cursorY += 5;
+  });
+
+  const roomLines = pdf.splitTextToSize(`Salle : ${roomLabel}`, availableWidth);
+  roomLines.forEach((line) => {
+    pdf.text(line, PAGE_MARGIN_X + 2, cursorY);
+    cursorY += 5;
+  });
+
+  pdf.text(`Fonction : ${typeLabel}`, PAGE_MARGIN_X + 2, cursorY);
+  cursorY += 5;
+  pdf.text(`Durée : ${duration}`, PAGE_MARGIN_X + 2, cursorY);
+  cursorY += 8;
+
+  pdf.setDrawColor(226, 232, 240);
+  pdf.setLineWidth(0.4);
+  pdf.line(PAGE_MARGIN_X, cursorY, width - PAGE_MARGIN_X, cursorY);
+  cursorY += 8;
+
+  return cursorY;
+}
+
+function addSummary(
+  pdf: jsPDF,
+  group: TeacherScheduleGroup,
+  cursorY: number,
+): number {
+  const width = pdf.internal.pageSize.getWidth();
+  const boxTop = cursorY;
+  const boxHeight = SUMMARY_BOX_HEIGHT;
+
+  pdf.setDrawColor(59, 130, 246);
+  pdf.setFillColor(219, 234, 254);
+  pdf.setLineWidth(0.6);
+  pdf.rect(PAGE_MARGIN_X, boxTop, width - PAGE_MARGIN_X * 2, boxHeight, "FD");
+
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(12);
+  pdf.setTextColor(37, 99, 235);
+  pdf.text("Récapitulatif", PAGE_MARGIN_X + 4, boxTop + 8);
+
+  pdf.setFont("helvetica", "normal");
+  pdf.setFontSize(11);
+  const totalDuration = group.missions.reduce(
+    (sum, mission) => sum + parseDuration(mission.duration),
+    0,
+  );
+  const summaryText = `${group.missions.length} mission${group.missions.length > 1 ? "s" : ""} – Charge totale estimée : ${formatDuration(totalDuration)}.`;
+  pdf.text(summaryText, PAGE_MARGIN_X + 4, boxTop + 16);
+
+  pdf.setTextColor(15, 23, 42);
+  return boxTop + boxHeight + 12;
+}
+
+function addClosing(pdf: jsPDF, cursorY: number): number {
+  const width = pdf.internal.pageSize.getWidth();
+  const closingLines = pdf.splitTextToSize(
+    "Nous vous remercions pour votre disponibilité et restons à votre disposition pour toute question relative à cette convocation.",
+    width - PAGE_MARGIN_X * 2,
+  );
+  pdf.setFont("helvetica", "normal");
+  pdf.setFontSize(11);
+  pdf.text(closingLines, PAGE_MARGIN_X, cursorY);
+  return cursorY + closingLines.length * 5 + 10;
+}
+
+function drawSignature(pdf: jsPDF, cursorY: number) {
+  const signatureX = PAGE_MARGIN_X;
+  const signatureY = cursorY + 12;
+
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(11);
+  pdf.text("Le Proviseur", signatureX, cursorY + 4);
+
+  pdf.setDrawColor(71, 85, 105);
+  pdf.setLineWidth(1);
+  const signatureStroke = [
+    [15, -14],
+    [20, 18],
+    [18, -10],
+    [16, 8],
+    [18, -6],
+    [20, 10],
+  ];
+  pdf.lines(signatureStroke, signatureX, signatureY, [1, 1], "S", false);
+  pdf.line(signatureX, signatureY + 6, signatureX + 55, signatureY + 6);
+
+  pdf.setFont("helvetica", "italic");
+  pdf.setFontSize(9);
+  pdf.text("Signature", signatureX, signatureY + 12);
+
+  return signatureY + 18;
+}
+
+function addConvocationPage(pdf: jsPDF, group: TeacherScheduleGroup) {
+  addHeader(pdf);
+  let cursorY = addIntro(pdf, group, PAGE_MARGIN_Y + 10);
+
+  for (const mission of group.missions) {
+    if (!mission) continue;
+    const availableHeight =
+      pdf.internal.pageSize.getHeight() - PAGE_MARGIN_Y - SUMMARY_BOX_HEIGHT - 40;
+    const missionHeight = measureMissionHeight(pdf, mission);
+    if (cursorY + missionHeight > availableHeight) {
+      pdf.addPage();
+      addHeader(pdf);
+      cursorY = addIntro(pdf, group, PAGE_MARGIN_Y + 10);
+    }
+    cursorY = addMission(pdf, mission, cursorY);
+  }
+
+  cursorY = addSummary(pdf, group, cursorY);
+  cursorY = addClosing(pdf, cursorY);
+  drawSignature(pdf, cursorY);
+}
+
+function normalizeFileName(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+export function downloadConvocationPdf(group: TeacherScheduleGroup) {
+  if (!group.missions.length) {
+    return;
+  }
+  const pdf = new jsPDF();
+  addConvocationPage(pdf, group);
+  const fileName = normalizeFileName(group.teacher || "convocation");
+  pdf.save(`convocation-${fileName || "surveillant"}.pdf`);
+}
+
+export function downloadAllConvocationsPdf(groups: TeacherScheduleGroup[]) {
+  const exportableGroups = groups.filter((group) => group.teacher && group.missions.length);
+  if (!exportableGroups.length) {
+    return;
+  }
+  const pdf = new jsPDF();
+  exportableGroups.forEach((group, index) => {
+    if (index > 0) {
+      pdf.addPage();
+    }
+    addConvocationPage(pdf, group);
+  });
+  pdf.save("convocations-surveillants.pdf");
+}

--- a/src/sections/ConvocationGenerator.tsx
+++ b/src/sections/ConvocationGenerator.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import { Download } from "lucide-react";
 
 import TypeBadge from "../components/TypeBadge";
 import {
@@ -18,6 +19,11 @@ import {
   type TeacherScheduleGroup,
 } from "../lib/dashboard-utils";
 import { useDashboardContext } from "../lib/dashboard-context";
+import ProviseurSignature from "../components/ProviseurSignature";
+import {
+  downloadAllConvocationsPdf,
+  downloadConvocationPdf,
+} from "../lib/convocation-pdf";
 
 const CalendarClockIcon = calendarClockIcon;
 const MapPinIcon = mapPinIcon;
@@ -83,6 +89,8 @@ export default function ConvocationGenerator() {
 
   const defaultTeacher = teacherOptions[0]?.value ?? "";
   const [selectedTeacher, setSelectedTeacher] = useState<string>(defaultTeacher);
+  const [isDownloadingSingle, setIsDownloadingSingle] = useState(false);
+  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
 
   useEffect(() => {
     if (!teacherOptions.length) {
@@ -98,6 +106,14 @@ export default function ConvocationGenerator() {
   const selectedGroup = useMemo(() => {
     return scheduleByTeacher.find((group) => group.teacher === selectedTeacher) ?? null;
   }, [scheduleByTeacher, selectedTeacher]);
+
+  const availableGroups = useMemo(
+    () =>
+      scheduleByTeacher.filter(
+        (group) => group.teacher && group.teacher !== "À assigner" && group.missions.length,
+      ),
+    [scheduleByTeacher],
+  );
 
   const totalDuration = useMemo(() => {
     if (!selectedGroup) {
@@ -127,6 +143,30 @@ export default function ConvocationGenerator() {
       : "Vous êtes convié"
     : "Vous êtes convié(e)";
 
+  const handleDownloadSingle = useCallback(() => {
+    if (!selectedGroup || isDownloadingSingle) {
+      return;
+    }
+    setIsDownloadingSingle(true);
+    try {
+      downloadConvocationPdf(selectedGroup);
+    } finally {
+      setIsDownloadingSingle(false);
+    }
+  }, [isDownloadingSingle, selectedGroup]);
+
+  const handleDownloadAll = useCallback(() => {
+    if (!availableGroups.length || isDownloadingAll) {
+      return;
+    }
+    setIsDownloadingAll(true);
+    try {
+      downloadAllConvocationsPdf(availableGroups);
+    } finally {
+      setIsDownloadingAll(false);
+    }
+  }, [availableGroups, isDownloadingAll]);
+
   return createPortal(
     <section
       id="convocation-view"
@@ -142,6 +182,26 @@ export default function ConvocationGenerator() {
         <p className="text-sm text-slate-500">
           Sélectionnez un surveillant pour obtenir une convocation prête à être envoyée avec toutes les informations clés.
         </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleDownloadSingle}
+          disabled={!hasMissions || isDownloadingSingle}
+          className="inline-flex items-center gap-2 rounded-lg border border-blue-600 bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-200 disabled:text-slate-500"
+        >
+          <Download className="h-4 w-4" aria-hidden="true" />
+          {isDownloadingSingle ? "Génération..." : "Télécharger la convocation"}
+        </button>
+        <button
+          type="button"
+          onClick={handleDownloadAll}
+          disabled={!availableGroups.length || isDownloadingAll}
+          className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+        >
+          <Download className="h-4 w-4" aria-hidden="true" />
+          {isDownloadingAll ? "Génération..." : "Télécharger toutes les convocations"}
+        </button>
       </div>
       <div className="space-y-2">
         <label htmlFor="convocation-teacher" className="text-sm font-medium text-slate-700">
@@ -188,6 +248,7 @@ export default function ConvocationGenerator() {
             <p>
               Nous vous remercions pour votre disponibilité et restons à votre disposition pour toute question relative à cette convocation.
             </p>
+            <ProviseurSignature />
           </div>
         ) : (
           <div className="flex items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-white/70 p-4 text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- add jsPDF support and utilities to build signed convocation PDFs
- expose download controls in the convocation tab including a signature display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daff3451108331b56672c231be22a0