### PR TITLE
Make room day column sticky in schedule table

### DIFF
--- a/src/sections/RoomsStatus.tsx
+++ b/src/sections/RoomsStatus.tsx
@@ -190,8 +190,18 @@ function RoomCell({ sessions }: { sessions: RoomSession[] }) {
 function RoomRow({ day }: { day: RoomScheduleDay }) {
   const isToday = isDayLabelToday(day.day);
   return (
-    <TableRow className={cn(isToday && "bg-amber-50/70")}>
-      <TableCell className="font-medium text-slate-900">
+    <TableRow
+      className={cn(
+        "hover:[&>td:first-child]:bg-slate-50",
+        isToday && "bg-amber-50/70 hover:[&>td:first-child]:bg-amber-50",
+      )}
+    >
+      <TableCell
+        className={cn(
+          "sticky left-0 z-10 bg-white font-medium text-slate-900",
+          isToday && "bg-amber-50",
+        )}
+      >
         {isToday ? (
           <div className="flex items-center gap-2">
             {day.day}
@@ -232,11 +242,14 @@ export default function RoomsStatus() {
           Chaque créneau est surligné selon le bloc horaire (matin, après-midi, etc.) pour faciliter la lecture.
         </p>
       </div>
-      <div className="overflow-x-auto">
-        <Table>
+      <div className="overflow-x-auto bg-white">
+        <Table className="relative">
           <TableHead>
             <TableRow>
-              <TableHeaderCell scope="col" className="rounded-l-lg">
+              <TableHeaderCell
+                scope="col"
+                className="sticky left-0 z-20 rounded-l-lg bg-slate-100"
+              >
                 Jour
               </TableHeaderCell>
               {roomColumns.map((column, index) => (


### PR DESCRIPTION
## Summary
- make the day header and first column sticky with appropriate backgrounds and stacking
- give the room schedule table a white background to keep the sticky column cleanly layered
- verified the schedule view remains readable on a narrow viewport while scrolling horizontally

## Testing
- npm install --legacy-peer-deps
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68db01e4a85483318ba7acaa2f6e8615