### PR TITLE
Add PDF export for convocation generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "bac_blanc_2512",
       "version": "0.0.0",
       "dependencies": {
+        "html2canvas": "^1.4.1",
+        "jspdf": "^2.5.1",
         "lucide-react": "^0.424.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -296,6 +298,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1473,6 +1484,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
@@ -1970,6 +1988,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2030,6 +2060,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.9",
@@ -2109,6 +2148,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/call-bind": {
@@ -2201,6 +2252,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2301,6 +2372,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2314,6 +2397,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2490,6 +2582,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3135,6 +3234,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3576,6 +3681,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -4169,6 +4287,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -4682,6 +4818,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4962,6 +5105,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5050,6 +5203,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -5108,6 +5268,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -5434,6 +5604,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -5712,6 +5892,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -5769,6 +5959,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -6005,6 +6204,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.20",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "lint": "eslint . --ext ts,tsx --max-warnings 0"
   },
   "dependencies": {
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1",
     "lucide-react": "^0.424.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
-    "devDependencies": {
-      "@types/node": "^20.16.5",
-      "@typescript-eslint/eslint-plugin": "^7.18.0",
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",

--- a/src/lib/convocation-pdf.ts
+++ b/src/lib/convocation-pdf.ts
@@ -1,0 +1,309 @@
+import html2canvas from "html2canvas";
+import { jsPDF } from "jspdf";
+
+import {
+  formatDuration,
+  parseDuration,
+  type TeacherScheduleGroup,
+} from "./dashboard-utils";
+import { type TeacherDirectoryEntry, typeVariants } from "./dashboard-data";
+
+const typeBadgeStyles: Record<
+  string,
+  { background: string; text: string; border: string }
+> = {
+  philosophie: {
+    background: "#e2e8f0",
+    text: "#1e293b",
+    border: "rgba(100, 116, 139, 0.4)",
+  },
+  specialite: {
+    background: "#dbeafe",
+    text: "#1d4ed8",
+    border: "rgba(59, 130, 246, 0.4)",
+  },
+  eaf: {
+    background: "#ede9fe",
+    text: "#6d28d9",
+    border: "rgba(109, 40, 217, 0.35)",
+  },
+  support: {
+    background: "#fef3c7",
+    text: "#b45309",
+    border: "rgba(217, 119, 6, 0.35)",
+  },
+  default: {
+    background: "#e2e8f0",
+    text: "#1e40af",
+    border: "rgba(37, 99, 235, 0.25)",
+  },
+};
+
+const sanitizeFilename = (value: string): string => {
+  const normalized = value.normalize("NFD").replace(/[^\p{Letter}\p{Number}]+/gu, "-");
+  const trimmed = normalized.replace(/^-+|-+$/g, "");
+  return trimmed.length ? trimmed.toLowerCase() : "convocation";
+};
+
+const createHiddenContainer = (): HTMLDivElement => {
+  const container = document.createElement("div");
+  container.style.position = "absolute";
+  container.style.top = "-10000px";
+  container.style.left = "-10000px";
+  container.style.width = "794px"; // A4 width at ~96 DPI
+  container.style.padding = "48px";
+  container.style.backgroundColor = "#ffffff";
+  container.style.boxSizing = "border-box";
+  container.style.fontFamily = "'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif";
+  container.style.lineHeight = "1.6";
+  container.style.color = "#0f172a";
+  container.style.boxShadow = "0 24px 48px rgba(15, 23, 42, 0.12)";
+  container.style.borderRadius = "16px";
+  container.style.border = "1px solid #e2e8f0";
+  container.style.display = "flex";
+  container.style.flexDirection = "column";
+  container.style.gap = "24px";
+  container.style.textRendering = "optimizeLegibility";
+  return container;
+};
+
+const createSectionTitle = (text: string): HTMLHeadingElement => {
+  const title = document.createElement("h2");
+  title.textContent = text;
+  title.style.fontSize = "20px";
+  title.style.fontWeight = "600";
+  title.style.color = "#1d4ed8";
+  title.style.margin = "0";
+  return title;
+};
+
+const createParagraph = (text: string): HTMLParagraphElement => {
+  const paragraph = document.createElement("p");
+  paragraph.textContent = text;
+  paragraph.style.margin = "0";
+  paragraph.style.fontSize = "14px";
+  paragraph.style.color = "#334155";
+  return paragraph;
+};
+
+const createMissionCard = (
+  mission: TeacherScheduleGroup["missions"][number],
+  index: number,
+): HTMLDivElement => {
+  const card = document.createElement("div");
+  card.style.padding = "16px";
+  card.style.borderRadius = "12px";
+  card.style.border = "1px solid #cbd5f5";
+  card.style.background = "linear-gradient(135deg, #f8fafc, #eef2ff)";
+  card.style.display = "flex";
+  card.style.flexDirection = "column";
+  card.style.gap = "8px";
+
+  const header = document.createElement("div");
+  header.style.display = "flex";
+  header.style.justifyContent = "space-between";
+  header.style.alignItems = "center";
+  header.style.gap = "16px";
+
+  const title = document.createElement("h3");
+  title.style.margin = "0";
+  title.style.fontSize = "16px";
+  title.style.fontWeight = "600";
+  title.style.color = "#1e3a8a";
+  title.textContent = `Mission ${index + 1}`;
+
+  const typeBadge = document.createElement("span");
+  typeBadge.style.display = "inline-flex";
+  typeBadge.style.alignItems = "center";
+  typeBadge.style.padding = "4px 10px";
+  typeBadge.style.borderRadius = "9999px";
+  typeBadge.style.fontSize = "12px";
+  typeBadge.style.fontWeight = "600";
+  typeBadge.style.letterSpacing = "0.02em";
+
+  const variant = typeVariants[mission.type ?? ""] ?? typeVariants.default;
+  const badgeStyle = typeBadgeStyles[mission.type ?? ""] ?? typeBadgeStyles.default;
+  typeBadge.textContent = variant.label;
+  typeBadge.style.backgroundColor = badgeStyle.background;
+  typeBadge.style.color = badgeStyle.text;
+  typeBadge.style.border = `1px solid ${badgeStyle.border}`;
+
+  header.append(title, typeBadge);
+
+  const detailList = document.createElement("ul");
+  detailList.style.margin = "0";
+  detailList.style.padding = "0";
+  detailList.style.listStyle = "none";
+  detailList.style.display = "flex";
+  detailList.style.flexDirection = "column";
+  detailList.style.gap = "4px";
+
+  const createDetailItem = (label: string, value: string): HTMLLIElement => {
+    const item = document.createElement("li");
+    item.style.fontSize = "13px";
+    item.style.color = "#1f2937";
+    item.textContent = `${label} ${value}`;
+    return item;
+  };
+
+  const roomLabel = mission.room && mission.room.trim() !== "-" ? mission.room : "Salle à confirmer";
+  const durationLabel = mission.duration
+    ? formatDuration(parseDuration(mission.duration))
+    : "Durée à préciser";
+
+  detailList.append(
+    createDetailItem("Date et horaire :", mission.datetime ?? "À préciser"),
+    createDetailItem("Salle :", roomLabel),
+    createDetailItem("Épreuve / fonction :", mission.mission ?? "À préciser"),
+    createDetailItem("Durée estimée :", durationLabel),
+  );
+
+  card.append(header, detailList);
+  return card;
+};
+
+const buildConvocationContent = (
+  group: TeacherScheduleGroup,
+  teacherEntry: TeacherDirectoryEntry | undefined,
+): HTMLDivElement => {
+  const container = createHiddenContainer();
+
+  const header = document.createElement("header");
+  header.style.display = "flex";
+  header.style.flexDirection = "column";
+  header.style.gap = "6px";
+
+  const title = document.createElement("h1");
+  title.textContent = "Convocation aux surveillances";
+  title.style.margin = "0";
+  title.style.fontSize = "26px";
+  title.style.fontWeight = "700";
+  title.style.color = "#0f172a";
+
+  const subtitle = document.createElement("p");
+  subtitle.textContent = "Baccalauréat blanc – Lycée Français Jean-Paul";
+  subtitle.style.margin = "0";
+  subtitle.style.fontSize = "14px";
+  subtitle.style.color = "#475569";
+
+  header.append(title, subtitle);
+
+  const salutation = teacherEntry?.civility ?? "Madame, Monsieur";
+  const teacherName = teacherEntry
+    ? `${teacherEntry.firstName} ${teacherEntry.lastName}`
+    : group.teacher;
+  const invitationSentence = teacherEntry
+    ? teacherEntry.gender === "female"
+      ? "Vous êtes conviée"
+      : "Vous êtes convié"
+    : "Vous êtes convié(e)";
+
+  const introduction = document.createElement("div");
+  introduction.style.display = "flex";
+  introduction.style.flexDirection = "column";
+  introduction.style.gap = "8px";
+
+  introduction.append(
+    createParagraph(`${salutation} ${teacherName},`),
+    createParagraph(
+      `${invitationSentence} à assurer les surveillances suivantes dans le cadre du baccalauréat blanc. ` +
+        "Vous trouverez ci-dessous les informations détaillées pour chaque mission.",
+    ),
+  );
+
+  const missionSection = document.createElement("section");
+  missionSection.style.display = "flex";
+  missionSection.style.flexDirection = "column";
+  missionSection.style.gap = "12px";
+
+  missionSection.append(createSectionTitle("Missions"));
+
+  group.missions.forEach((mission, index) => {
+    missionSection.append(createMissionCard(mission, index));
+  });
+
+  const totalDuration = group.missions.reduce(
+    (sum, mission) => sum + parseDuration(mission.duration),
+    0,
+  );
+
+  const summary = document.createElement("section");
+  summary.style.padding = "18px";
+  summary.style.borderRadius = "12px";
+  summary.style.backgroundColor = "#dbeafe";
+  summary.style.border = "1px solid rgba(37, 99, 235, 0.3)";
+  summary.style.display = "flex";
+  summary.style.flexDirection = "column";
+  summary.style.gap = "6px";
+
+  const summaryTitle = document.createElement("h2");
+  summaryTitle.textContent = "Récapitulatif";
+  summaryTitle.style.margin = "0";
+  summaryTitle.style.fontSize = "18px";
+  summaryTitle.style.fontWeight = "600";
+  summaryTitle.style.color = "#1d4ed8";
+
+  const summaryParagraph = createParagraph(
+    `${group.missions.length} mission${group.missions.length > 1 ? "s" : ""} – Charge totale estimée : ${formatDuration(
+      totalDuration,
+    )}.`,
+  );
+
+  summary.append(summaryTitle, summaryParagraph);
+
+  const closing = document.createElement("p");
+  closing.textContent =
+    "Merci pour votre disponibilité. N'hésitez pas à contacter l'administration en cas de question relative à cette convocation.";
+  closing.style.margin = "0";
+  closing.style.fontSize = "14px";
+  closing.style.color = "#334155";
+
+  container.append(header, introduction, missionSection, summary, closing);
+
+  return container;
+};
+
+export async function downloadConvocationPdf(
+  group: TeacherScheduleGroup,
+  teacherEntry: TeacherDirectoryEntry | undefined,
+): Promise<void> {
+  if (!group || group.missions.length === 0) {
+    throw new Error("Aucune mission sélectionnée");
+  }
+
+  const content = buildConvocationContent(group, teacherEntry);
+  document.body.appendChild(content);
+
+  try {
+    const canvas = await html2canvas(content, {
+      scale: 2,
+      backgroundColor: "#ffffff",
+    });
+    const imgData = canvas.toDataURL("image/png");
+
+    const pdf = new jsPDF({
+      orientation: "portrait",
+      unit: "pt",
+      format: "a4",
+    });
+
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+
+    const renderWidth = canvas.width;
+    const renderHeight = canvas.height;
+    const ratio = Math.min(pageWidth / renderWidth, pageHeight / renderHeight);
+    const width = renderWidth * ratio;
+    const height = renderHeight * ratio;
+    const offsetX = (pageWidth - width) / 2;
+    const offsetY = (pageHeight - height) / 2;
+
+    pdf.addImage(imgData, "PNG", offsetX, offsetY, width, height);
+
+    const filename = `convocation-${sanitizeFilename(group.teacher)}.pdf`;
+    pdf.save(filename);
+  } finally {
+    content.remove();
+  }
+}
+

--- a/src/sections/ConvocationGenerator.tsx
+++ b/src/sections/ConvocationGenerator.tsx
@@ -18,6 +18,7 @@ import {
   type TeacherScheduleGroup,
 } from "../lib/dashboard-utils";
 import { useDashboardContext } from "../lib/dashboard-context";
+import { downloadConvocationPdf } from "../lib/convocation-pdf";
 
 const CalendarClockIcon = calendarClockIcon;
 const MapPinIcon = mapPinIcon;
@@ -83,6 +84,7 @@ export default function ConvocationGenerator() {
 
   const defaultTeacher = teacherOptions[0]?.value ?? "";
   const [selectedTeacher, setSelectedTeacher] = useState<string>(defaultTeacher);
+  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
 
   useEffect(() => {
     if (!teacherOptions.length) {
@@ -126,6 +128,21 @@ export default function ConvocationGenerator() {
       ? "Vous êtes conviée"
       : "Vous êtes convié"
     : "Vous êtes convié(e)";
+
+  const handleDownload = async () => {
+    if (!selectedGroup || !hasMissions || isGeneratingPdf) {
+      return;
+    }
+    try {
+      setIsGeneratingPdf(true);
+      await downloadConvocationPdf(selectedGroup, teacherEntry);
+    } catch (error) {
+      console.error("PDF generation failed", error);
+      alert("Impossible de générer la convocation. Veuillez réessayer.");
+    } finally {
+      setIsGeneratingPdf(false);
+    }
+  };
 
   return createPortal(
     <section
@@ -188,6 +205,16 @@ export default function ConvocationGenerator() {
             <p>
               Nous vous remercions pour votre disponibilité et restons à votre disposition pour toute question relative à cette convocation.
             </p>
+            <div>
+              <button
+                type="button"
+                onClick={handleDownload}
+                disabled={!hasMissions || isGeneratingPdf}
+                className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:text-slate-500"
+              >
+                {isGeneratingPdf ? "Génération en cours..." : "Télécharger la convocation (PDF)"}
+              </button>
+            </div>
           </div>
         ) : (
           <div className="flex items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-white/70 p-4 text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- add html2canvas and jspdf dependencies for PDF export support
- implement a reusable helper that renders a convocation summary and triggers PDF download
- integrate a download button into the convocation generator UI with loading state and error handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db96d61dec8331acbedd90ede1a1df