### PR TITLE
Add placeholder tab for exam room setup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Hero from "./sections/Hero";
 import RoomsStatus from "./sections/RoomsStatus";
 import SurveillanceTable from "./sections/SurveillanceTable";
 import ConvocationGenerator from "./sections/ConvocationGenerator";
+import RoomSetup from "./sections/RoomSetup";
 
 export default function App() {
   return (
@@ -14,6 +15,7 @@ export default function App() {
         <Header />
         <Hero />
         <ExamDashboard>
+          <RoomSetup />
           <SurveillanceTable />
           <ConvocationGenerator />
           <RoomsStatus />

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -13,6 +13,7 @@ import {
   Info,
   LayoutGrid,
   LifeBuoy,
+  Settings,
   MapPin,
   PenLine,
   Sun,
@@ -592,12 +593,13 @@ export const roomSchedule: RoomScheduleDay[] = [
 ];
 
 export interface DashboardTab {
-  id: "teacher" | "convocation" | "room" | "day";
+  id: "setup" | "teacher" | "convocation" | "room" | "day";
   label: string;
   Icon: LucideIcon;
 }
 
 export const dashboardTabs: DashboardTab[] = [
+  { id: "setup", label: "Paramétrage des salles", Icon: Settings },
   { id: "teacher", label: "Vue par enseignant", Icon: Users },
   { id: "convocation", label: "Convocations", Icon: ClipboardList },
   { id: "room", label: "Vue par salle", Icon: LayoutGrid },

--- a/src/sections/RoomSetup.tsx
+++ b/src/sections/RoomSetup.tsx
@@ -1,0 +1,47 @@
+import { createPortal } from "react-dom";
+import { Settings } from "lucide-react";
+
+import { useDashboardContext } from "../lib/dashboard-context";
+
+const SettingsIcon = Settings;
+
+export default function RoomSetup() {
+  const { activeView, container } = useDashboardContext();
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(
+    <section
+      id="setup-view"
+      data-view-section="setup"
+      role="tabpanel"
+      aria-labelledby="setup-tab"
+      tabIndex={activeView === "setup" ? 0 : -1}
+      aria-hidden={activeView === "setup" ? "false" : "true"}
+      className={`${activeView === "setup" ? "" : "hidden"} space-y-6`}
+    >
+      <div>
+        <h3 className="text-xl font-semibold text-slate-900">
+          Paramétrage des salles d’examen
+        </h3>
+        <p className="text-sm text-slate-500">
+          Centralisez ici la configuration des salles, des capacités et des besoins matériels pour les sessions d’examen.
+        </p>
+      </div>
+      <div className="rounded-lg border border-dashed border-slate-300 bg-white p-6 text-center shadow-sm">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-600">
+          <SettingsIcon className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h4 className="mt-4 text-base font-semibold text-slate-900">
+          Section en construction
+        </h4>
+        <p className="mt-2 text-sm text-slate-500">
+          Le paramétrage des salles d’examen sera bientôt disponible. En attendant, continuez à consulter les autres vues du tableau de bord.
+        </p>
+      </div>
+    </section>,
+    container,
+  );
+}


### PR DESCRIPTION
## Summary
- add a new "Paramétrage des salles" tab ahead of the teacher view in the dashboard
- scaffold a RoomSetup section with placeholder messaging while the feature is built
- register the new tab in the dashboard data and application layout

## Testing
- npm run build *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf5c96044833191cdbc1126b232eb