### PR TITLE
Fix mobilized rooms key figure

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -196,7 +196,7 @@ export interface KeyFigure {
 }
 
 export const keyFigures: KeyFigure[] = [
-  { value: "7", label: "Salles mobilisées" },
+  { value: "6", label: "Salles mobilisées" },
   { value: "4", label: "Épreuves", extra: "Spécialités N°1 & N°2, Philosophie, EAF" },
   { value: "3,7", unit: "h", label: "Durée moyenne", extra: "31 missions planifiées" },
   { value: "114", unit: "h", label: "Surveillance cumulée", extra: "Inclut les missions de renfort" },


### PR DESCRIPTION
## Summary
- update the key figure for mobilized rooms to reflect the six rooms actually used

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68dc15d2ff308331979caf84268de707