### PR TITLE
Remove accommodation alert notices from dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -208,8 +208,8 @@ export interface AccommodationGroup {
   description: string;
   students: string[];
   rooms: string;
-  note: string;
-  noteClasses: string;
+  note?: string;
+  noteClasses?: string;
 }
 
 export const accommodationGroups: AccommodationGroup[] = [
@@ -225,8 +225,6 @@ export const accommodationGroups: AccommodationGroup[] = [
       "ZARB Frédy",
     ],
     rooms: "9, 12, 13, 14.",
-    note: "Silence requis dans les salles 10 et 11.",
-    noteClasses: "bg-amber-100 text-amber-800",
   },
   {
     icon: { Icon: UserCheck, bg: "bg-purple-100", color: "text-purple-600" },
@@ -239,8 +237,6 @@ export const accommodationGroups: AccommodationGroup[] = [
       "KERDUDO Zeina",
     ],
     rooms: "10, 12, 13, 14.",
-    note: "Silence requis dans la salle 11.",
-    noteClasses: "bg-amber-100 text-amber-800",
   },
 ];
 

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -61,10 +61,16 @@ function AccommodationCard({ group }: { group: AccommodationGroup }) {
         <p className="mb-2">
           <span className="font-semibold">Salles :</span> {group.rooms}
         </p>
-        <div className={`mt-4 flex items-center rounded-lg p-3 text-sm ${group.noteClasses}`}>
-          <AlertTriangleIcon className="mr-3 h-5 w-5 flex-shrink-0" />
-          <span>{group.note}</span>
-        </div>
+        {group.note ? (
+          <div
+            className={`mt-4 flex items-center rounded-lg p-3 text-sm ${
+              group.noteClasses ?? ""
+            }`}
+          >
+            <AlertTriangleIcon className="mr-3 h-5 w-5 flex-shrink-0" />
+            <span>{group.note}</span>
+          </div>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make accommodation notes optional in the data model and remove outdated alerts from the dashboard
- guard the accommodation card UI so the alert banner only appears when a note is provided
- add a gitignore to keep build output and dependencies out of version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc15e364dc8331ae7006bd0973349b