### PR TITLE
Move reminder banner above dashboard tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import Announcements from "./sections/Announcements";
 import ExamDashboard from "./sections/ExamDashboard";
-import Footer from "./sections/Footer";
 import Header from "./sections/Header";
 import Hero from "./sections/Hero";
 import RoomsStatus from "./sections/RoomsStatus";
@@ -21,7 +20,6 @@ export default function App() {
           <RoomsStatus />
           <Announcements />
         </ExamDashboard>
-        <Footer />
       </div>
     </div>
   );

--- a/src/sections/ExamDashboard.tsx
+++ b/src/sections/ExamDashboard.tsx
@@ -10,6 +10,7 @@ import {
 import { dashboardTabs } from "../lib/dashboard-data";
 import { DashboardContext } from "../lib/dashboard-context";
 import type { DashboardView } from "../lib/dashboard-utils";
+import Footer from "./Footer";
 
 export default function ExamDashboard({ children }: { children?: ReactNode }) {
   const [activeView, setActiveView] = useState<DashboardView>("teacher");
@@ -74,6 +75,9 @@ export default function ExamDashboard({ children }: { children?: ReactNode }) {
       </h2>
       <DashboardContext.Provider value={contextValue}>
         <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-md">
+          <div className="mb-4">
+            <Footer />
+          </div>
           <div
             className="flex flex-wrap items-center gap-2 border-b border-slate-200 pb-4"
             role="tablist"


### PR DESCRIPTION
## Summary
- place the reminder banner within the exam dashboard just above the tab buttons
- remove the footer placement at the bottom of the app since the banner now sits near the tabs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc1b413dfc8331908d0fe978c58da9