### PR TITLE
Add lycée logo to home page

### DIFF
--- a/src/features/home/components/HomeCallToActionCard.tsx
+++ b/src/features/home/components/HomeCallToActionCard.tsx
@@ -7,7 +7,7 @@ interface HomeCallToActionCardProps {
   icon: LucideIcon;
   iconLabel: string;
   title: string;
-  subtitle: string;
+  subtitle?: string;
   description: string;
   footerLabel: string;
   meta?: ReactNode;
@@ -38,9 +38,11 @@ export default function HomeCallToActionCard({
         </div>
 
         <div className="space-y-3">
-          <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
-            {subtitle}
-          </p>
+          {subtitle ? (
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+              {subtitle}
+            </p>
+          ) : null}
           <h2 className="text-2xl font-bold text-slate-900 sm:text-3xl">{title}</h2>
           {meta}
           <p className="text-sm text-slate-500 sm:text-base">{description}</p>

--- a/src/features/home/components/HomeHero.tsx
+++ b/src/features/home/components/HomeHero.tsx
@@ -1,12 +1,28 @@
 interface HomeHeroProps {
+  logoSrc?: string;
+  logoAlt?: string;
   subtitle: string;
   title: string;
   description: string;
 }
 
-export default function HomeHero({ subtitle, title, description }: HomeHeroProps) {
+export default function HomeHero({
+  logoSrc,
+  logoAlt,
+  subtitle,
+  title,
+  description,
+}: HomeHeroProps) {
   return (
     <div className="max-w-4xl space-y-6">
+      {logoSrc ? (
+        <img
+          src={logoSrc}
+          alt={logoAlt ?? ""}
+          className="h-24 w-auto"
+          loading="lazy"
+        />
+      ) : null}
       <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
         {subtitle}
       </p>

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -1,4 +1,8 @@
 export const HOME_PAGE_CONTENT = {
+  logo: {
+    src: "https://i.imgur.com/W3EZ93D.png",
+    alt: "Logo du Lycée Français Jean-Prince",
+  },
   subtitle: "Espace examens blancs LFJP",
   title:
     "Toute l'organisation des examens blancs centralisée pour les enseignants du LFJP",
@@ -9,7 +13,7 @@ export const HOME_PAGE_CONTENT = {
 export const HOME_DASHBOARD_ENTRY = {
   to: "/examens-blancs",
   iconLabel: "Accéder à l'organisation des examens blancs",
-  subtitle: "Dessin interactif",
+  subtitle: "",
   title: "Baccalauréat blanc 1ère et Terminale",
   dateLabel: "10, 11 et 12 décembre 2025",
   description:

--- a/src/features/home/pages/HomePage.tsx
+++ b/src/features/home/pages/HomePage.tsx
@@ -10,6 +10,8 @@ export default function HomePage() {
   return (
     <HomeLayout>
       <HomeHero
+        logoSrc={HOME_PAGE_CONTENT.logo?.src}
+        logoAlt={HOME_PAGE_CONTENT.logo?.alt}
         subtitle={HOME_PAGE_CONTENT.subtitle}
         title={HOME_PAGE_CONTENT.title}
         description={HOME_PAGE_CONTENT.description}


### PR DESCRIPTION
## Summary
- add the lycée logo to the home hero section and expose logo metadata in the home page constants
- hide the call-to-action subtitle when undefined so the "DESSIN INTERACTIF" label no longer appears

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4e1b2cb4833192567a82f1e28d90