### PR TITLE
Show both LFJP and AEFE logos on the home hero

### DIFF
--- a/src/features/home/components/HomeHero.tsx
+++ b/src/features/home/components/HomeHero.tsx
@@ -1,27 +1,37 @@
+interface HomeHeroLogo {
+  src: string;
+  alt?: string;
+}
+
 interface HomeHeroProps {
-  logoSrc?: string;
-  logoAlt?: string;
+  logos?: HomeHeroLogo[];
   subtitle: string;
   title: string;
   description: string;
 }
 
 export default function HomeHero({
-  logoSrc,
-  logoAlt,
+  logos,
   subtitle,
   title,
   description,
 }: HomeHeroProps) {
+  const hasLogos = logos && logos.length > 0;
+
   return (
     <div className="max-w-4xl space-y-6">
-      {logoSrc ? (
-        <img
-          src={logoSrc}
-          alt={logoAlt ?? ""}
-          className="h-24 w-auto"
-          loading="lazy"
-        />
+      {hasLogos ? (
+        <div className="flex flex-wrap items-center gap-4 sm:gap-6">
+          {logos?.map((logo) => (
+            <img
+              key={logo.src}
+              src={logo.src}
+              alt={logo.alt ?? ""}
+              className="h-16 w-auto flex-shrink-0 rounded-lg border border-slate-200 bg-white object-contain shadow-sm"
+              loading="lazy"
+            />
+          ))}
+        </div>
       ) : null}
       <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
         {subtitle}

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -1,8 +1,14 @@
 export const HOME_PAGE_CONTENT = {
-  logo: {
-    src: "https://i.imgur.com/W3EZ93D.png",
-    alt: "Logo du Lycée Français Jean-Prince",
-  },
+  logos: [
+    {
+      src: "https://i.imgur.com/W3EZ93D.png",
+      alt: "Logo du Lycée Français Jacques Prévert de Saly",
+    },
+    {
+      src: "https://i.imgur.com/0YmGlXO.png",
+      alt: "Logo de l'AEFE",
+    },
+  ],
   subtitle: "Espace examens blancs LFJP",
   title:
     "Toute l'organisation des examens blancs centralisée pour les enseignants du LFJP",

--- a/src/features/home/pages/HomePage.tsx
+++ b/src/features/home/pages/HomePage.tsx
@@ -10,8 +10,7 @@ export default function HomePage() {
   return (
     <HomeLayout>
       <HomeHero
-        logoSrc={HOME_PAGE_CONTENT.logo?.src}
-        logoAlt={HOME_PAGE_CONTENT.logo?.alt}
+        logos={HOME_PAGE_CONTENT.logos}
         subtitle={HOME_PAGE_CONTENT.subtitle}
         title={HOME_PAGE_CONTENT.title}
         description={HOME_PAGE_CONTENT.description}


### PR DESCRIPTION
## Summary
- allow the home hero to display multiple logos so the LFJP and AEFE marks appear just like on the bac blanc page
- store both logo URLs in the home page content constants and pass them through the home page component

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js file in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4fc1b594833186cd90ad5d14a1af