### PR TITLE
Remove broken home page logo

### DIFF
--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -1,10 +1,6 @@
 export const HOME_PAGE_CONTENT = {
   logos: [
     {
-      src: "https://i.imgur.com/W3EZ93D.png",
-      alt: "Logo du Lycée Français Jacques Prévert de Saly",
-    },
-    {
       src: "https://i.imgur.com/0YmGlXO.png",
       alt: "Logo de l'AEFE",
     },


### PR DESCRIPTION
## Summary
- remove the broken LFJP logo from the home hero content so that only the valid AEFE logo renders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc538678f08331a5fef1652e7fa6b4