### PR TITLE
Améliore la carte d'aménagement et supprime les salles

### DIFF
--- a/src/features/exam-dashboard/components/Hero.tsx
+++ b/src/features/exam-dashboard/components/Hero.tsx
@@ -11,12 +11,12 @@ const AlertTriangleIcon = alertTriangleIcon;
 
 function KeyFigureItem({ figure }: { figure: KeyFigure }) {
   return (
-    <div>
-      <p className="text-4xl font-bold text-blue-600">
+    <div className="rounded-2xl bg-white/70 p-4 shadow-sm ring-1 ring-slate-100">
+      <p className="text-4xl font-semibold text-blue-600">
         {figure.value}
-        {figure.unit ? <span className="text-2xl">{figure.unit}</span> : null}
+        {figure.unit ? <span className="ml-1 text-2xl text-blue-500">{figure.unit}</span> : null}
       </p>
-      <p className="mt-1 text-sm text-slate-500">{figure.label}</p>
+      <p className="mt-2 text-sm font-medium text-slate-600">{figure.label}</p>
       {figure.extra ? (
         <p className="mt-1 text-xs text-slate-400">{figure.extra}</p>
       ) : null}
@@ -26,50 +26,71 @@ function KeyFigureItem({ figure }: { figure: KeyFigure }) {
 
 function KeyFiguresCard() {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-md">
-      <div className="mb-4 flex items-center gap-4">
-        <div className="rounded-full bg-blue-100 p-3">
+    <article className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-blue-100 bg-gradient-to-br from-white via-blue-50/40 to-slate-50 p-6 shadow-lg ring-1 ring-blue-100/60">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-blue-200/40 blur-3xl"
+      />
+      <div className="relative mb-6 flex items-center gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-500/10">
           <InfoIcon className="h-6 w-6 text-blue-600" />
         </div>
-        <h3 className="text-xl font-semibold">Informations Clés</h3>
+        <div>
+          <h3 className="text-xl font-semibold text-slate-900">Informations Clés</h3>
+          <p className="text-sm text-slate-500">
+            Un aperçu rapide des indicateurs de suivi de l'examen blanc.
+          </p>
+        </div>
       </div>
-      <div className="mt-6 grid grid-cols-2 gap-x-2 gap-y-4 text-center">
+      <div className="relative mt-auto grid grid-cols-2 gap-3">
         {keyFigures.map((figure) => (
           <KeyFigureItem key={`${figure.label}-${figure.value}`} figure={figure} />
         ))}
       </div>
-    </div>
+    </article>
   );
 }
 
 function AccommodationCard({ group }: { group: AccommodationGroup }) {
   const { Icon, bg, color } = group.icon;
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-md">
-      <div className="mb-4 flex items-center gap-4">
-        <div className={`${bg} rounded-full p-3`}>
+    <article className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-white via-slate-50/70 to-slate-100 p-6 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-10 -top-10 h-36 w-36 rounded-full bg-slate-200/50 blur-3xl"
+      />
+      <div className="relative flex items-center gap-4">
+        <div className={`flex h-12 w-12 items-center justify-center rounded-2xl ${bg}`}>
           <Icon className={`${color} h-6 w-6`} />
         </div>
-        <h3 className="text-xl font-semibold">{group.title}</h3>
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">{group.title}</h3>
+          <p className="text-sm text-slate-500">{group.description}</p>
+        </div>
       </div>
-      <div className="text-slate-700">
-        <p className="mb-2 font-medium">{group.description}</p>
-        <p className="mb-4 text-sm">{group.students.join(", ")}</p>
-        <p className="mb-2">
-          <span className="font-semibold">Salles :</span> {group.rooms}
-        </p>
+      <div className="relative mt-6 flex flex-1 flex-col">
+        <div className="flex flex-wrap gap-2">
+          {group.students.map((student) => (
+            <span
+              key={`${group.title}-${student}`}
+              className="rounded-full bg-white/80 px-3 py-1 text-sm font-medium text-slate-700 shadow-sm ring-1 ring-slate-200"
+            >
+              {student}
+            </span>
+          ))}
+        </div>
         {group.note ? (
           <div
-            className={`mt-4 flex items-center rounded-lg p-3 text-sm ${
+            className={`mt-6 flex items-start gap-3 rounded-2xl bg-amber-50/80 p-4 text-sm font-medium text-amber-800 shadow-inner ring-1 ring-amber-100 ${
               group.noteClasses ?? ""
             }`}
           >
-            <AlertTriangleIcon className="mr-3 h-5 w-5 flex-shrink-0" />
+            <AlertTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-500" />
             <span>{group.note}</span>
           </div>
         ) : null}
       </div>
-    </div>
+    </article>
   );
 }
 

--- a/src/features/exam-dashboard/data/dashboard-data.ts
+++ b/src/features/exam-dashboard/data/dashboard-data.ts
@@ -207,7 +207,6 @@ export interface AccommodationGroup {
   title: string;
   description: string;
   students: string[];
-  rooms: string;
   note?: string;
   noteClasses?: string;
 }
@@ -224,7 +223,6 @@ export const accommodationGroups: AccommodationGroup[] = [
       "FALL CLAMENS Omar",
       "ZARB Frédy",
     ],
-    rooms: "9, 12, 13, 14.",
   },
   {
     icon: { Icon: UserCheck, bg: "bg-purple-100", color: "text-purple-600" },
@@ -236,7 +234,6 @@ export const accommodationGroups: AccommodationGroup[] = [
       "SARR Sokhna Faty",
       "KERDUDO Zeina",
     ],
-    rooms: "10, 12, 13, 14.",
   },
 ];
 


### PR DESCRIPTION
## Summary
- refine the hero cards styling for the key figures and accommodation groups to create a fuller, more polished layout
- replace the student list presentation with pill tags and remove the room lines from each accommodation card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf7e8f3188331b7edbb7f451c64a2