### PR TITLE
Add February 2026 math exam dashboard

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,9 @@ const HomePage = lazy(() => import("../features/home/pages/HomePage"));
 const ExamDashboardPage = lazy(
   () => import("../features/exam-dashboard/pages/ExamDashboardPage"),
 );
+const MathExamDashboardPage = lazy(
+  () => import("../features/math-exam-dashboard/pages/MathExamDashboardPage"),
+);
 
 export default function App() {
   return (
@@ -12,6 +15,10 @@ export default function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/examens-blancs" element={<ExamDashboardPage />} />
+        <Route
+          path="/examens-blancs/mathematiques-2026-02-13"
+          element={<MathExamDashboardPage />}
+        />
       </Routes>
     </Suspense>
   );

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -23,3 +23,14 @@ export const HOME_DASHBOARD_ENTRY = {
   footerLabel: "Découvrir l'organisation",
 };
 
+export const HOME_MATH_EXAM_ENTRY = {
+  to: "/examens-blancs/mathematiques-2026-02-13",
+  iconLabel: "Consulter l'organisation du bac blanc de mathématiques",
+  subtitle: "", 
+  title: "Bac blanc de mathématiques",
+  dateLabel: "13 février 2026",
+  description:
+    "Accédez à la répartition des salles, aux convocations et aux informations pratiques pour l'épreuve de mathématiques.",
+  footerLabel: "Voir le planning",
+};
+

--- a/src/features/home/pages/HomePage.tsx
+++ b/src/features/home/pages/HomePage.tsx
@@ -4,7 +4,11 @@ import HomeCallToActionCard from "../components/HomeCallToActionCard";
 import HomeEventMeta from "../components/HomeEventMeta";
 import HomeHero from "../components/HomeHero";
 import HomeLayout from "../components/HomeLayout";
-import { HOME_DASHBOARD_ENTRY, HOME_PAGE_CONTENT } from "../constants";
+import {
+  HOME_DASHBOARD_ENTRY,
+  HOME_MATH_EXAM_ENTRY,
+  HOME_PAGE_CONTENT,
+} from "../constants";
 
 export default function HomePage() {
   return (
@@ -16,24 +20,20 @@ export default function HomePage() {
         description={HOME_PAGE_CONTENT.description}
       />
 
-      <div className="flex w-full max-w-3xl flex-col items-center gap-6">
-        <HomeCallToActionCard
-          to={HOME_DASHBOARD_ENTRY.to}
-          icon={GraduationCap}
-          iconLabel={HOME_DASHBOARD_ENTRY.iconLabel}
-          subtitle={HOME_DASHBOARD_ENTRY.subtitle}
-          title={HOME_DASHBOARD_ENTRY.title}
-          description={HOME_DASHBOARD_ENTRY.description}
-          footerLabel={HOME_DASHBOARD_ENTRY.footerLabel}
-          meta={
-            <HomeEventMeta
-              icon={CalendarDays}
-              label={HOME_DASHBOARD_ENTRY.dateLabel}
-              description=""
-            />
-          }
-        />
-
+      <div className="grid w-full max-w-4xl grid-cols-1 gap-6 lg:grid-cols-2">
+        {[HOME_DASHBOARD_ENTRY, HOME_MATH_EXAM_ENTRY].map((entry) => (
+          <HomeCallToActionCard
+            key={entry.to}
+            to={entry.to}
+            icon={GraduationCap}
+            iconLabel={entry.iconLabel}
+            subtitle={entry.subtitle}
+            title={entry.title}
+            description={entry.description}
+            footerLabel={entry.footerLabel}
+            meta={<HomeEventMeta icon={CalendarDays} label={entry.dateLabel} description="" />}
+          />
+        ))}
       </div>
     </HomeLayout>
   );

--- a/src/features/math-exam-dashboard/components/Announcements.tsx
+++ b/src/features/math-exam-dashboard/components/Announcements.tsx
@@ -1,0 +1,141 @@
+import { useMemo } from "react";
+import { createPortal } from "react-dom";
+
+import TodayBadge from "./TodayBadge";
+import TypeBadge from "./TypeBadge";
+import {
+  clockIcon,
+  roomSchedule,
+  surveillanceSchedule,
+} from "../data";
+import {
+  buildDaySchedule,
+  getBlockHighlight,
+  isDayLabelToday,
+  type DaySchedule,
+  type DayScheduleEntry,
+  type DaySlot,
+} from "../utils";
+import { useDashboardContext } from "../context";
+
+const ClockIcon = clockIcon;
+
+function DaySession({ entry }: { entry: DayScheduleEntry }) {
+  const isTeacherDefined = Boolean(entry.teacher);
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
+      <div className="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <span>{entry.room}</span>
+        <TypeBadge type={entry.type} compact />
+      </div>
+      <div className="mt-2 text-sm text-slate-700">
+        {isTeacherDefined ? (
+          <span className="font-semibold text-slate-900">{entry.teacher}</span>
+        ) : (
+          <span className="italic text-slate-400">Surveillant à confirmer</span>
+        )}
+      </div>
+      {entry.detail ? <p className="text-xs text-slate-500">{entry.detail}</p> : null}
+    </div>
+  );
+}
+
+function SlotCard({ slot }: { slot: DaySlot }) {
+  const highlight = getBlockHighlight({
+    label: slot.label ?? undefined,
+    time: slot.time ?? undefined,
+  });
+  const classes = ["rounded-lg", "border", "border-slate-200", "bg-slate-50", "p-3"];
+  if (highlight) {
+    classes.push(highlight.background, highlight.border);
+  }
+  const labelNeeded = slot.label && (!slot.time || slot.label !== slot.time);
+  return (
+    <div className={classes.join(" ")}>
+      <div className="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
+        <div className="flex items-center gap-2">
+          <ClockIcon className="h-4 w-4 text-slate-500" />
+          {slot.time ?? slot.label ?? "Horaire à confirmer"}
+        </div>
+        {labelNeeded && slot.label ? (
+          <span
+            className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+              highlight ? `${highlight.badgeBackground} ${highlight.badgeText}` : "bg-slate-200 text-slate-600"
+            }`}
+          >
+            {slot.label}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-3 grid gap-3 md:grid-cols-2">
+        {slot.entries.length ? (
+          slot.entries.map((entry, index) => <DaySession key={index} entry={entry} />)
+        ) : (
+          <p className="text-xs italic text-slate-400">Aucune surveillance prévue.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DayCard({ schedule }: { schedule: DaySchedule }) {
+  const isToday = isDayLabelToday(schedule.day);
+  return (
+    <article className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="text-lg font-semibold text-slate-900">{schedule.day}</h4>
+        {isToday ? <TodayBadge /> : null}
+      </div>
+      <div className="mt-4 space-y-4">
+        {schedule.slots.length ? (
+          schedule.slots.map((slot) => <SlotCard key={slot.key} slot={slot} />)
+        ) : (
+          <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
+            Aucun créneau planifié pour cette journée.
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export default function Announcements() {
+  const { activeView, container } = useDashboardContext();
+  const daySchedule = useMemo(
+    () => buildDaySchedule(roomSchedule, surveillanceSchedule),
+    [],
+  );
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(
+    <section
+      id="day-view"
+      data-view-section="day"
+      role="tabpanel"
+      aria-labelledby="day-tab"
+      tabIndex={activeView === "day" ? 0 : -1}
+      aria-hidden={activeView === "day" ? "false" : "true"}
+      className={`${activeView === "day" ? "" : "hidden"} space-y-6`}
+    >
+      <div>
+        <h3 className="text-xl font-semibold text-slate-900">Planning condensé par jour</h3>
+        <p className="text-sm text-slate-500">
+          Retrouvez une vue globale de chaque journée, organisée par créneaux horaires comme dans un emploi du temps.
+        </p>
+      </div>
+      <div className="space-y-4">
+        {daySchedule.length ? (
+          daySchedule.map((schedule) => <DayCard key={schedule.day} schedule={schedule} />)
+        ) : (
+          <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
+            Aucune journée planifiée.
+          </div>
+        )}
+      </div>
+    </section>,
+    container,
+  );
+}

--- a/src/features/math-exam-dashboard/components/ConvocationGenerator.tsx
+++ b/src/features/math-exam-dashboard/components/ConvocationGenerator.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+
+import TypeBadge from "./TypeBadge";
+import {
+  alertCircleIcon,
+  calendarClockIcon,
+  clipboardListIcon,
+  mapPinIcon,
+  surveillanceSchedule,
+  teacherDirectoryByShortName,
+  typeVariants,
+} from "../data";
+import { useDashboardContext } from "../context";
+import { downloadConvocationPdf } from "../services";
+import {
+  buildTeacherSchedule,
+  formatDuration,
+  parseDuration,
+  type TeacherScheduleGroup,
+} from "../utils";
+
+const CalendarClockIcon = calendarClockIcon;
+const MapPinIcon = mapPinIcon;
+const ClipboardListIcon = clipboardListIcon;
+const AlertCircleIcon = alertCircleIcon;
+
+type TeacherOption = {
+  value: string;
+  label: string;
+};
+
+function ConvocationMission({ mission }: { mission: TeacherScheduleGroup["missions"][number] }) {
+  const roomLabel = mission.room && mission.room.trim() !== "-" ? mission.room : "Salle à confirmer";
+  const typeLabel = typeVariants[mission.type ?? ""]?.label ?? typeVariants.default.label;
+  const duration = mission.duration ? formatDuration(parseDuration(mission.duration)) : "Durée à préciser";
+
+  return (
+    <li className="rounded-lg border border-slate-200 bg-white/80 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm font-semibold text-slate-800">
+        <span className="inline-flex items-center gap-2">
+          <CalendarClockIcon className="h-4 w-4 text-slate-500" />
+          {mission.datetime}
+        </span>
+        <TypeBadge type={mission.type} compact />
+      </div>
+      <div className="mt-3 space-y-1 text-sm text-slate-600">
+        <div className="flex items-start gap-2">
+          <MapPinIcon className="mt-0.5 h-4 w-4 text-slate-400" />
+          <span>
+            <span className="font-semibold text-slate-700">Salle :</span> {roomLabel}
+          </span>
+        </div>
+        <div className="flex items-start gap-2">
+          <ClipboardListIcon className="mt-0.5 h-4 w-4 text-slate-400" />
+          <span>
+            <span className="font-semibold text-slate-700">Épreuve / fonction :</span> {mission.mission}
+          </span>
+        </div>
+        <div className="pl-6 text-xs uppercase tracking-wide text-slate-500">Fonction : {typeLabel}</div>
+        <div className="pl-6 text-xs uppercase tracking-wide text-slate-500">Durée : {duration}</div>
+      </div>
+    </li>
+  );
+}
+
+export default function ConvocationGenerator() {
+  const { activeView, container } = useDashboardContext();
+
+  const scheduleByTeacher = useMemo(
+    () => buildTeacherSchedule(surveillanceSchedule),
+    [],
+  );
+
+  const assignedTeacherGroups = useMemo(() => {
+    return scheduleByTeacher.filter(
+      (group) => group.teacher && group.teacher !== "À assigner" && group.missions.length > 0,
+    );
+  }, [scheduleByTeacher]);
+
+  const teacherOptions = useMemo<TeacherOption[]>(() => {
+    return assignedTeacherGroups.map((group) => {
+      const entry = teacherDirectoryByShortName[group.teacher];
+      const label = entry ? `${entry.firstName} ${entry.lastName}` : group.teacher;
+      return { value: group.teacher, label };
+    });
+  }, [assignedTeacherGroups]);
+
+  const defaultTeacher = teacherOptions[0]?.value ?? "";
+  const [selectedTeacher, setSelectedTeacher] = useState<string>(defaultTeacher);
+  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const [isGeneratingAll, setIsGeneratingAll] = useState(false);
+
+  useEffect(() => {
+    if (!teacherOptions.length) {
+      setSelectedTeacher("");
+      return;
+    }
+    const exists = teacherOptions.some((option) => option.value === selectedTeacher);
+    if (!exists) {
+      setSelectedTeacher(defaultTeacher);
+    }
+  }, [defaultTeacher, selectedTeacher, teacherOptions]);
+
+  const selectedGroup = useMemo(() => {
+    return scheduleByTeacher.find((group) => group.teacher === selectedTeacher) ?? null;
+  }, [scheduleByTeacher, selectedTeacher]);
+
+  const totalDuration = useMemo(() => {
+    if (!selectedGroup) {
+      return 0;
+    }
+    return selectedGroup.missions.reduce(
+      (sum, mission) => sum + parseDuration(mission.duration),
+      0,
+    );
+  }, [selectedGroup]);
+
+  if (!container) {
+    return null;
+  }
+
+  const hasMissions = Boolean(selectedGroup && selectedGroup.missions.length);
+  const teacherEntry = selectedGroup
+    ? teacherDirectoryByShortName[selectedGroup.teacher]
+    : undefined;
+  const salutation = teacherEntry?.civility ?? "Madame, Monsieur";
+  const teacherDisplayName = teacherEntry
+    ? `${teacherEntry.firstName} ${teacherEntry.lastName}`
+    : selectedGroup?.teacher ?? "";
+  const invitationSentence = teacherEntry
+    ? teacherEntry.gender === "female"
+      ? "Vous êtes conviée"
+      : "Vous êtes convié"
+    : "Vous êtes convié(e)";
+
+  const handleDownload = async () => {
+    if (!selectedGroup || !hasMissions || isGeneratingPdf || isGeneratingAll) {
+      return;
+    }
+    try {
+      setIsGeneratingPdf(true);
+      await downloadConvocationPdf(selectedGroup, teacherEntry);
+    } catch (error) {
+      console.error("PDF generation failed", error);
+      alert("Impossible de générer la convocation. Veuillez réessayer.");
+    } finally {
+      setIsGeneratingPdf(false);
+    }
+  };
+
+  const handleDownloadAll = async () => {
+    if (isGeneratingAll || isGeneratingPdf) {
+      return;
+    }
+    if (!assignedTeacherGroups.length) {
+      alert("Aucune convocation disponible pour le téléchargement.");
+      return;
+    }
+    try {
+      setIsGeneratingAll(true);
+      for (const group of assignedTeacherGroups) {
+        const entry = teacherDirectoryByShortName[group.teacher];
+        await downloadConvocationPdf(group, entry);
+      }
+    } catch (error) {
+      console.error("PDF generation failed", error);
+      alert("Impossible de générer la convocation. Veuillez réessayer.");
+    } finally {
+      setIsGeneratingAll(false);
+    }
+  };
+
+  return createPortal(
+    <section
+      id="convocation-view"
+      data-view-section="convocation"
+      role="tabpanel"
+      aria-labelledby="convocation-tab"
+      tabIndex={activeView === "convocation" ? 0 : -1}
+      aria-hidden={activeView === "convocation" ? "false" : "true"}
+      className={`${activeView === "convocation" ? "" : "hidden"} space-y-6`}
+    >
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold text-slate-900">Générateur de convocation</h3>
+        <p className="text-sm text-slate-500">
+          Sélectionnez un surveillant pour obtenir une convocation prête à être envoyée avec toutes les informations clés.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="convocation-teacher" className="text-sm font-medium text-slate-700">
+          Surveillant
+        </label>
+        <select
+          id="convocation-teacher"
+          className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          value={selectedTeacher}
+          onChange={(event) => setSelectedTeacher(event.target.value)}
+        >
+          {teacherOptions.length === 0 ? (
+            <option value="" disabled>
+              Aucun surveillant disponible
+            </option>
+          ) : null}
+          {teacherOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {selectedGroup && hasMissions ? (
+        <div className="space-y-4 rounded-xl border border-blue-100 bg-blue-50/70 p-6">
+          <div className="space-y-1 text-sm text-slate-600">
+            <p className="text-slate-500">{salutation},</p>
+            <p>
+              {invitationSentence} à assurer les surveillances suivantes pour le baccalauréat blanc. Merci de prendre
+              connaissance des informations ci-dessous.
+            </p>
+          </div>
+          <ul className="space-y-3">
+            {selectedGroup.missions.map((mission) => (
+              <ConvocationMission key={`${mission.datetime}-${mission.mission}`} mission={mission} />
+            ))}
+          </ul>
+          <div className="rounded-lg bg-white/70 p-4 text-sm text-slate-600">
+            <p>
+              <span className="font-semibold text-slate-700">Durée totale d'engagement :</span>{" "}
+              {formatDuration(totalDuration)}
+            </p>
+            <p className="mt-1 text-xs text-slate-500">
+              Merci d'arriver 15 minutes avant le début de chaque épreuve pour la mise en place.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={!hasMissions || isGeneratingPdf || isGeneratingAll}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors duration-200 hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+            >
+              Télécharger la convocation de {teacherDisplayName}
+            </button>
+            <button
+              type="button"
+              onClick={handleDownloadAll}
+              disabled={isGeneratingAll || isGeneratingPdf}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-blue-200 bg-white px-4 py-2 text-sm font-semibold text-blue-700 shadow-sm transition-colors duration-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-300"
+            >
+              Télécharger toutes les convocations
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-3 rounded-xl border border-amber-200 bg-amber-50/80 p-4 text-sm text-amber-800">
+          <AlertCircleIcon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
+          <p className="leading-relaxed">
+            Aucun surveillant n'a encore été assigné. Complétez le tableau des surveillances pour activer la génération des
+            convocations.
+          </p>
+        </div>
+      )}
+    </section>,
+    container,
+  );
+}

--- a/src/features/math-exam-dashboard/components/ExamDashboard.tsx
+++ b/src/features/math-exam-dashboard/components/ExamDashboard.tsx
@@ -1,0 +1,129 @@
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { DashboardContext } from "../context";
+import { useDashboardTabs } from "../hooks";
+import type { DashboardView } from "../utils";
+import DashboardFooter from "./Footer";
+
+interface ExamDashboardProps {
+  children?: ReactNode;
+}
+
+export default function ExamDashboard({ children }: ExamDashboardProps) {
+  const [activeView, setActiveView] = useState<DashboardView>("teacher");
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const tabRefs = useRef<Partial<Record<DashboardView, HTMLButtonElement | null>>>({});
+  const { tabIds, tabs } = useDashboardTabs();
+
+  const handleTabClick = useCallback((view: DashboardView) => {
+    setActiveView(view);
+  }, []);
+
+  const setContainerRef = useCallback((node: HTMLDivElement | null) => {
+    setContainer(node);
+  }, []);
+
+  const focusTab = useCallback((view: DashboardView) => {
+    const tab = tabRefs.current[view];
+    tab?.focus();
+  }, []);
+
+  const handleTabKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, currentId: DashboardView) => {
+      const { key } = event;
+      const currentIndex = tabIds.indexOf(currentId);
+
+      if (currentIndex === -1) {
+        return;
+      }
+
+      let nextView: DashboardView | null = null;
+
+      switch (key) {
+        case "ArrowRight":
+          nextView = tabIds[(currentIndex + 1) % tabIds.length];
+          break;
+        case "ArrowLeft":
+          nextView = tabIds[(currentIndex - 1 + tabIds.length) % tabIds.length];
+          break;
+        case "Home":
+          nextView = tabIds[0];
+          break;
+        case "End":
+          nextView = tabIds[tabIds.length - 1];
+          break;
+        default:
+          break;
+      }
+
+      if (nextView) {
+        event.preventDefault();
+        setActiveView(nextView);
+        focusTab(nextView);
+      }
+    },
+    [focusTab, tabIds],
+  );
+
+  const contextValue = useMemo(
+    () => ({ activeView, setActiveView, container, setContainer: setContainerRef }),
+    [activeView, container, setContainerRef],
+  );
+
+  return (
+    <section aria-labelledby="views-title" className="space-y-6">
+      <h2 id="views-title" className="sr-only">
+        Affichage des plannings
+      </h2>
+      <DashboardContext.Provider value={contextValue}>
+        <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-md">
+          <div className="mb-4">
+            <DashboardFooter />
+          </div>
+          <div
+            className="flex flex-wrap items-center gap-2 border-b border-slate-200 pb-4"
+            role="tablist"
+            aria-label="Affichage des plannings"
+          >
+            {tabs.map(({ id, label, Icon }) => {
+              const isActive = activeView === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  aria-controls={`${id}-view`}
+                  id={`${id}-tab`}
+                  onClick={() => handleTabClick(id)}
+                  onKeyDown={(event) => handleTabKeyDown(event, id)}
+                  tabIndex={isActive ? 0 : -1}
+                  ref={(node) => {
+                    tabRefs.current[id] = node;
+                  }}
+                  className={`view-tab inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+                    isActive
+                      ? "bg-blue-600 text-white shadow"
+                      : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                  }`}
+                >
+                  <Icon className="h-4 w-4" />
+                  <span>{label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <div className="mt-6 space-y-10" ref={setContainerRef} />
+        </div>
+        {children}
+      </DashboardContext.Provider>
+    </section>
+  );
+}

--- a/src/features/math-exam-dashboard/components/Footer.tsx
+++ b/src/features/math-exam-dashboard/components/Footer.tsx
@@ -1,0 +1,11 @@
+export default function Footer() {
+  return (
+    <footer className="rounded-lg bg-blue-100 p-4 text-center text-blue-800">
+      <p className="font-semibold">Rappel :</p>
+      <p>
+        Merci de transmettre les sujets au plus tard le 6 février et d'être
+        présents 20 min avant le début de l'épreuve.
+      </p>
+    </footer>
+  );
+}

--- a/src/features/math-exam-dashboard/components/Header.tsx
+++ b/src/features/math-exam-dashboard/components/Header.tsx
@@ -1,0 +1,24 @@
+export default function Header() {
+  return (
+    <header className="space-y-4">
+      <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex items-center gap-4">
+          <img
+            alt="Logo du Lycée Français Jacques Prévert de Saly"
+            className="h-16 flex-shrink-0 rounded-lg border border-slate-200 bg-white object-contain shadow-sm"
+            src="https://i.imgur.com/0YmGlXO.png"
+          />
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+              Lycée Français Jacques Prévert de Saly
+            </p>
+            <h1 className="text-3xl font-bold text-slate-900">
+              Bac blanc de mathématiques
+            </h1>
+          </div>
+        </div>
+      </div>
+      <p className="text-lg text-slate-600">Vendredi 13 février 2026 • 09h00</p>
+    </header>
+  );
+}

--- a/src/features/math-exam-dashboard/components/Hero.tsx
+++ b/src/features/math-exam-dashboard/components/Hero.tsx
@@ -1,0 +1,111 @@
+import {
+  accommodationGroups,
+  alertTriangleIcon,
+  infoIcon,
+  keyFigures,
+} from "../data";
+import type { AccommodationGroup, KeyFigure } from "../utils";
+
+const InfoIcon = infoIcon;
+const AlertTriangleIcon = alertTriangleIcon;
+
+function KeyFigureItem({ figure }: { figure: KeyFigure }) {
+  return (
+    <div className="rounded-2xl bg-white/70 p-4 shadow-sm ring-1 ring-slate-100">
+      <p className="text-4xl font-semibold text-blue-600">
+        {figure.value}
+        {figure.unit ? <span className="ml-1 text-2xl text-blue-500">{figure.unit}</span> : null}
+      </p>
+      <p className="mt-2 text-sm font-medium text-slate-600">{figure.label}</p>
+      {figure.extra ? (
+        <p className="mt-1 text-xs text-slate-400">{figure.extra}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function KeyFiguresCard() {
+  return (
+    <article className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-blue-100 bg-gradient-to-br from-white via-blue-50/40 to-slate-50 p-6 shadow-lg ring-1 ring-blue-100/60">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-blue-200/40 blur-3xl"
+      />
+      <div className="relative mb-6 flex items-center gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-500/10">
+          <InfoIcon className="h-6 w-6 text-blue-600" />
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold text-slate-900">Informations Clés</h3>
+          <p className="text-sm text-slate-500">
+            Un aperçu rapide des indicateurs de suivi de l'examen blanc.
+          </p>
+        </div>
+      </div>
+      <div className="relative mt-auto grid grid-cols-2 gap-3">
+        {keyFigures.map((figure) => (
+          <KeyFigureItem key={`${figure.label}-${figure.value}`} figure={figure} />
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function AccommodationCard({ group }: { group: AccommodationGroup }) {
+  const { Icon, bg, color } = group.icon;
+  return (
+    <article className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-white via-slate-50/70 to-slate-100 p-6 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-10 -top-10 h-36 w-36 rounded-full bg-slate-200/50 blur-3xl"
+      />
+      <div className="relative flex items-center gap-4">
+        <div className={`flex h-12 w-12 items-center justify-center rounded-2xl ${bg}`}>
+          <Icon className={`${color} h-6 w-6`} />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">{group.title}</h3>
+          <p className="text-sm text-slate-500">{group.description}</p>
+        </div>
+      </div>
+      <div className="relative mt-6 flex flex-1 flex-col">
+        <div className="flex flex-wrap gap-2">
+          {group.students.map((student) => (
+            <span
+              key={`${group.title}-${student}`}
+              className="rounded-full bg-white/80 px-3 py-1 text-sm font-medium text-slate-700 shadow-sm ring-1 ring-slate-200"
+            >
+              {student}
+            </span>
+          ))}
+        </div>
+        {group.note ? (
+          <div
+            className={`mt-6 flex items-start gap-3 rounded-2xl bg-amber-50/80 p-4 text-sm font-medium text-amber-800 shadow-inner ring-1 ring-amber-100 ${
+              group.noteClasses ?? ""
+            }`}
+          >
+            <AlertTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-500" />
+            <span>{group.note}</span>
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+export default function Hero() {
+  return (
+    <section aria-labelledby="overview-title" className="space-y-4">
+      <h2 id="overview-title" className="sr-only">
+        Informations générales
+      </h2>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <KeyFiguresCard />
+        {accommodationGroups.map((group) => (
+          <AccommodationCard key={group.title} group={group} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/math-exam-dashboard/components/NavigationButtons.tsx
+++ b/src/features/math-exam-dashboard/components/NavigationButtons.tsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+import { Home } from "lucide-react";
+
+interface BackToHomeButtonProps {
+  to?: string;
+}
+
+export function BackToHomeButton({ to = "/" }: BackToHomeButtonProps) {
+  return (
+    <Link
+      to={to}
+      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-colors duration-200 hover:border-slate-300 hover:bg-slate-100"
+    >
+      <Home className="h-4 w-4" aria-hidden="true" />
+      Accueil
+    </Link>
+  );
+}

--- a/src/features/math-exam-dashboard/components/RoomSetup.tsx
+++ b/src/features/math-exam-dashboard/components/RoomSetup.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { LayoutGrid, Users } from "lucide-react";
+
+import { useDashboardContext } from "../context";
+
+const examRooms: { name: string; examCapacity: number }[] = [
+  { name: "S10", examCapacity: 13 },
+  { name: "S11", examCapacity: 15 },
+  { name: "S11 COOP", examCapacity: 12 },
+  { name: "S14", examCapacity: 12 },
+];
+
+const totalExamCapacity = examRooms.reduce(
+  (accumulator, room) => accumulator + room.examCapacity,
+  0,
+);
+
+export default function RoomSetup() {
+  const { activeView, container } = useDashboardContext();
+  const [studentCount, setStudentCount] = useState(52);
+
+  const sliderMax = useMemo(
+    () => Math.max(totalExamCapacity, studentCount, 120),
+    [studentCount],
+  );
+
+  type RoomAllocation = {
+    name: string;
+    assigned: number;
+    capacity: number;
+  };
+
+  const autoDistribution = useMemo<RoomAllocation[]>(() => {
+    let remaining = studentCount;
+
+    return examRooms.map((room) => {
+      const assigned = Math.min(room.examCapacity, Math.max(remaining, 0));
+      remaining = Math.max(remaining - room.examCapacity, 0);
+
+      return {
+        name: room.name,
+        assigned,
+        capacity: room.examCapacity,
+      };
+    });
+  }, [studentCount]);
+
+  const [manualAssignments, setManualAssignments] = useState(autoDistribution);
+
+  useEffect(() => {
+    setManualAssignments(autoDistribution);
+  }, [autoDistribution]);
+
+  const totalAssigned = useMemo(
+    () =>
+      manualAssignments.reduce(
+        (accumulator, room) => accumulator + room.assigned,
+        0,
+      ),
+    [manualAssignments],
+  );
+
+  const roomsUsed = useMemo(
+    () => manualAssignments.filter((room) => room.assigned > 0).length,
+    [manualAssignments],
+  );
+  const capacityDelta = totalExamCapacity - totalAssigned;
+  const freeSeats = Math.max(capacityDelta, 0);
+  const overCapacity = Math.max(totalAssigned - totalExamCapacity, 0);
+  const studentsLeftToAssign = Math.max(studentCount - totalAssigned, 0);
+  const extraAssignedStudents = Math.max(totalAssigned - studentCount, 0);
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(
+    <section
+      id="setup-view"
+      data-view-section="setup"
+      role="tabpanel"
+      aria-labelledby="setup-tab"
+      tabIndex={activeView === "setup" ? 0 : -1}
+      aria-hidden={activeView === "setup" ? "false" : "true"}
+      className={`${activeView === "setup" ? "" : "hidden"} space-y-6`}
+    >
+      <div>
+        <h3 className="text-xl font-semibold text-slate-900">
+          Paramétrage des salles d’examen
+        </h3>
+        <p className="text-sm text-slate-500">
+          Centralisez ici la configuration des salles, des capacités et des besoins matériels pour les sessions d’examen.
+        </p>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+          <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-6 py-4">
+            <div>
+              <h4 className="text-base font-semibold text-slate-900">
+                Capacité des salles au format examen
+              </h4>
+              <p className="mt-1 text-sm text-slate-500">
+                Liste des salles disponibles avec la capacité maximale configurée pour les épreuves écrites.
+              </p>
+            </div>
+            <span className="hidden rounded-full bg-blue-100 p-3 text-blue-600 sm:inline-flex">
+              <LayoutGrid className="h-5 w-5" aria-hidden="true" />
+            </span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200 text-left">
+              <thead className="bg-slate-50 text-sm font-medium text-slate-600">
+                <tr>
+                  <th scope="col" className="px-6 py-3">
+                    Salle
+                  </th>
+                  <th scope="col" className="px-6 py-3">
+                    Capacité (format examen)
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 text-sm text-slate-700">
+                {examRooms.map((room) => (
+                  <tr key={room.name}>
+                    <th scope="row" className="whitespace-nowrap px-6 py-4 font-medium text-slate-900">
+                      {room.name}
+                    </th>
+                    <td className="px-6 py-4">{room.examCapacity}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <aside className="flex flex-col justify-between gap-4 rounded-lg border border-slate-200 bg-white p-6 text-slate-700 shadow-sm">
+          <div className="flex items-center gap-3">
+            <span className="rounded-full bg-emerald-100 p-3 text-emerald-600">
+              <Users className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div>
+              <p className="text-sm font-medium text-slate-500">Capacité totale</p>
+              <p className="text-2xl font-semibold text-slate-900">{totalExamCapacity} candidats</p>
+            </div>
+          </div>
+          <p className="text-sm text-slate-500">
+            Les capacités ci-dessus correspondent à la configuration des salles en mode examen (tables individuelles, distanciation, matériel nécessaire). Utilisez ces données pour planifier la répartition des candidats.
+          </p>
+        </aside>
+      </div>
+      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+        <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-6 py-4">
+          <div>
+            <h4 className="text-base font-semibold text-slate-900">
+              Simulateur de répartition des candidats
+            </h4>
+            <p className="mt-1 text-sm text-slate-500">
+              Ajustez le nombre de candidats attendus pour visualiser la répartition automatique dans les salles, puis adaptez manuellement la répartition si besoin.
+            </p>
+          </div>
+          <span className="hidden rounded-full bg-blue-100 p-3 text-blue-600 sm:inline-flex">
+            <Users className="h-5 w-5" aria-hidden="true" />
+          </span>
+        </div>
+        <div className="space-y-6 p-6">
+          <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
+            <label className="space-y-2">
+              <span className="text-sm font-medium text-slate-600">Nombre de candidats</span>
+              <input
+                type="range"
+                min={0}
+                max={sliderMax}
+                value={studentCount}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  setStudentCount(Number.isNaN(value) ? 0 : value);
+                }}
+                className="block w-full accent-blue-600"
+              />
+            </label>
+            <label className="space-y-2">
+              <span className="text-sm font-medium text-slate-600 sr-only md:not-sr-only">
+                Saisir précisément le nombre de candidats
+              </span>
+              <input
+                type="number"
+                min={0}
+                value={studentCount}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  setStudentCount(Number.isNaN(value) ? 0 : value);
+                }}
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-right text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200 text-left">
+              <thead className="bg-slate-50 text-sm font-medium text-slate-600">
+                <tr>
+                  <th scope="col" className="px-4 py-3">
+                    Salle
+                  </th>
+                  <th scope="col" className="px-4 py-3">
+                    Capacité
+                  </th>
+                  <th scope="col" className="px-4 py-3">
+                    Candidats affectés
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 text-sm text-slate-700">
+                {manualAssignments.map((room) => (
+                  <tr key={room.name}>
+                    <th scope="row" className="whitespace-nowrap px-4 py-3 font-medium text-slate-900">
+                      {room.name}
+                    </th>
+                    <td className="px-4 py-3">{room.capacity}</td>
+                    <td className="px-4 py-3">
+                      <input
+                        type="number"
+                        min={0}
+                        max={room.capacity}
+                        value={room.assigned}
+                        onChange={(event) => {
+                          const rawValue = Number(event.target.value);
+                          const safeValue = Number.isNaN(rawValue) ? 0 : rawValue;
+                          const value = Math.min(
+                            Math.max(safeValue, 0),
+                            room.capacity,
+                          );
+
+                          setManualAssignments((previous) =>
+                            previous.map((currentRoom) =>
+                              currentRoom.name === room.name
+                                ? {
+                                    ...currentRoom,
+                                    assigned: value,
+                                  }
+                                : currentRoom,
+                            ),
+                          );
+                        }}
+                        className="w-24 rounded-md border border-slate-300 px-3 py-2 text-right text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                        aria-label={`Nombre de candidats à placer dans la salle ${room.name}`}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex flex-col gap-3 rounded-md bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            <p>
+              Répartition actuelle : {totalAssigned} candidat{totalAssigned > 1 ? "s" : ""} affecté{totalAssigned > 1 ? "s" : ""} dans {roomsUsed} salle{roomsUsed > 1 ? "s" : ""}.
+            </p>
+            {freeSeats > 0 ? (
+              <p>Il reste {freeSeats} place{freeSeats > 1 ? "s" : ""} disponibles.</p>
+            ) : capacityDelta === 0 ? (
+              <p>Toutes les places sont occupées.</p>
+            ) : (
+              <p className="text-red-600">
+                Attention : {overCapacity} candidat{overCapacity > 1 ? "s" : ""} en trop par rapport à la capacité totale.
+              </p>
+            )}
+            {studentsLeftToAssign > 0 && (
+              <p>
+                Il reste {studentsLeftToAssign} candidat{studentsLeftToAssign > 1 ? "s" : ""} à placer pour atteindre l'objectif de {studentCount} candidat{studentCount > 1 ? "s" : ""}.
+              </p>
+            )}
+            {extraAssignedStudents > 0 && (
+              <p>
+                Vous avez réparti {extraAssignedStudents} candidat{extraAssignedStudents > 1 ? "s" : ""} de plus que l'objectif fixé ({studentCount}).
+              </p>
+            )}
+            <button
+              type="button"
+              onClick={() => setManualAssignments(autoDistribution)}
+              className="self-start rounded-md border border-blue-200 bg-white px-3 py-2 text-sm font-medium text-blue-600 shadow-sm transition hover:border-blue-300 hover:text-blue-700"
+            >
+              Réinitialiser la répartition automatique
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>,
+    container,
+  );
+}

--- a/src/features/math-exam-dashboard/components/RoomsStatus.tsx
+++ b/src/features/math-exam-dashboard/components/RoomsStatus.tsx
@@ -1,0 +1,507 @@
+import { useMemo } from "react";
+import { createPortal } from "react-dom";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+} from "../../../shared/components";
+import { cn } from "../../../shared/lib";
+import TodayBadge from "./TodayBadge";
+import TypeBadge from "./TypeBadge";
+import {
+  roomColumns,
+  roomSchedule,
+  surveillanceSchedule,
+  type RoomColumn,
+} from "../data";
+import { useDashboardContext } from "../context";
+import {
+  buildSupportSessionsByRoom,
+  getBlockHighlight,
+  getTypeVariant,
+  isDayLabelToday,
+  type RoomScheduleDay,
+  type RoomSession,
+} from "../utils";
+
+const roomColumnDefinitions = roomColumns.map((room) => ({
+  id: room,
+  label: room,
+}));
+
+function BlockLabel({ session }: { session: RoomSession }) {
+  const highlight = getBlockHighlight(session);
+  if (!session.label) {
+    return null;
+  }
+  const classes = [
+    "inline-flex",
+    "items-center",
+    "gap-1",
+    "rounded-full",
+    "px-2",
+    "py-0.5",
+    "text-[10px]",
+    "font-semibold",
+    "uppercase",
+    "tracking-wide",
+  ];
+  if (highlight) {
+    classes.push(highlight.badgeBackground, highlight.badgeText);
+  } else {
+    classes.push("bg-slate-200", "text-slate-600");
+  }
+  return <span className={classes.join(" ")}>{session.label}</span>;
+}
+
+function SessionCard({ session }: { session: RoomSession }) {
+  const highlight = getBlockHighlight(session);
+  const variant = getTypeVariant(session.type);
+  const classes = [
+    "flex",
+    "flex-col",
+    "items-center",
+    "gap-2",
+    "rounded-lg",
+    "border",
+    "p-3",
+    variant.cardBorder,
+    variant.cardBackground,
+  ];
+
+  if (highlight) {
+    classes.push(highlight.background, highlight.border);
+  }
+  if (session.highlight) {
+    classes.push("ring-2", "ring-amber-300", "shadow-sm");
+  }
+
+  const showLabel = Boolean(session.label);
+  const showBadge = Boolean(session.type);
+  const headerNeeded = showLabel || showBadge;
+
+  return (
+    <div className={classes.join(" ")}>
+      {headerNeeded ? (
+        <div
+          className={`flex w-full items-center ${
+            showLabel && showBadge ? "justify-between" : "justify-start"
+          } gap-2`}
+        >
+          {showLabel ? <BlockLabel session={session} /> : null}
+          {showBadge ? <div>{session.type ? <TypeBadge type={session.type} compact /> : null}</div> : null}
+        </div>
+      ) : null}
+      <div className="flex flex-col items-center gap-1 text-center">
+        {session.time ? (
+          <div className="text-xs font-semibold text-slate-700">{session.time}</div>
+        ) : (
+          <div className="text-xs italic text-slate-400">Horaire à confirmer</div>
+        )}
+        {session.teacher ? (
+          <div className={`text-sm font-semibold ${variant.textColor}`}>{session.teacher}</div>
+        ) : (
+          <div className="text-xs italic text-slate-400">Surveillant à confirmer</div>
+        )}
+        {session.detail ? <div className="text-xs text-slate-600">{session.detail}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+const normalizeLabel = (value?: string): string => value?.toLowerCase() ?? "";
+
+const extractStartHour = (time?: string): number | null => {
+  if (!time) {
+    return null;
+  }
+  const match = time.match(/(\d{1,2})h/);
+  if (!match) {
+    return null;
+  }
+  return Number.parseInt(match[1], 10);
+};
+
+const extractStartMinutes = (time?: string): number | null => {
+  if (!time) {
+    return null;
+  }
+  const match = time.match(/(\d{1,2})h(\d{2})?/);
+  if (!match) {
+    return null;
+  }
+  const hours = Number.parseInt(match[1], 10);
+  const minutes = match[2] ? Number.parseInt(match[2], 10) : 0;
+  return hours * 60 + minutes;
+};
+
+const getSessionSortValue = (session: RoomSession): number => {
+  const startMinutes = extractStartMinutes(session.time);
+  if (startMinutes !== null) {
+    return startMinutes;
+  }
+  const label = normalizeLabel(session.label);
+  if (label.includes("matin")) {
+    return 8 * 60;
+  }
+  if (label.includes("après") || label.includes("apres")) {
+    return 13 * 60;
+  }
+  return Number.POSITIVE_INFINITY;
+};
+
+const isAfternoonSession = (session?: RoomSession): boolean => {
+  if (!session) {
+    return false;
+  }
+  const label = normalizeLabel(session.label);
+  if (label.includes("après") || label.includes("apres")) {
+    return true;
+  }
+  if (label.includes("matin")) {
+    return false;
+  }
+  const startHour = extractStartHour(session.time);
+  return startHour !== null && startHour >= 12;
+};
+
+const isMorningSession = (session?: RoomSession): boolean => {
+  if (!session) {
+    return false;
+  }
+  const label = normalizeLabel(session.label);
+  if (label.includes("matin")) {
+    return true;
+  }
+  if (label.includes("après") || label.includes("apres")) {
+    return false;
+  }
+  const startHour = extractStartHour(session.time);
+  return startHour !== null && startHour < 12;
+};
+
+function RoomCell({ sessions }: { sessions: RoomSession[] }) {
+  if (!sessions.length) {
+    return <TableCell className="text-center" />;
+  }
+
+  const hasMultipleSessions = sessions.length > 1;
+  const [singleSession] = sessions;
+
+  let verticalAlignment = "justify-center";
+  if (!hasMultipleSessions && singleSession) {
+    if (isAfternoonSession(singleSession)) {
+      verticalAlignment = "justify-end";
+    } else if (isMorningSession(singleSession)) {
+      verticalAlignment = "justify-start";
+    }
+  }
+
+  const shouldReserveMorningSpace =
+    !hasMultipleSessions && singleSession && isAfternoonSession(singleSession);
+
+  const containerClasses = cn(
+    "flex h-full flex-col",
+    hasMultipleSessions || shouldReserveMorningSpace ? "items-stretch gap-3" : "items-center",
+    verticalAlignment,
+  );
+
+  return (
+    <TableCell className="min-w-[11rem] px-4 py-3 text-center align-top sm:min-w-0 sm:px-6 sm:py-4">
+      <div className={containerClasses}>
+        {shouldReserveMorningSpace ? (
+          <div aria-hidden className="invisible">
+            <SessionCard session={singleSession} />
+          </div>
+        ) : null}
+        {sessions.map((session, index) => (
+          <SessionCard key={index} session={session} />
+        ))}
+      </div>
+    </TableCell>
+  );
+}
+
+function RoomRow({ day }: { day: RoomScheduleDay }) {
+  const isToday = isDayLabelToday(day.day);
+  const stickyShadow = isToday
+    ? "shadow-[inset_-16px_0_16px_-16px_rgba(217,119,6,0.45)]"
+    : "shadow-[inset_-16px_0_16px_-16px_rgba(15,23,42,0.25)]";
+  return (
+    <TableRow
+      className={cn(
+        "hover:[&>td:first-child]:bg-slate-50",
+        isToday && "bg-amber-50/70 hover:[&>td:first-child]:bg-amber-50",
+      )}
+    >
+      <TableCell
+        className={cn(
+          "sticky left-0 z-10 whitespace-nowrap bg-slate-50 font-semibold text-slate-900",
+          "align-top px-4 py-3 text-left sm:px-6 sm:py-4",
+          stickyShadow,
+          isToday && "bg-amber-100/60 text-amber-900",
+        )}
+      >
+        <div className="flex flex-col gap-2">
+          <span>{day.day}</span>
+          {isToday ? <TodayBadge /> : null}
+        </div>
+      </TableCell>
+      {roomColumnDefinitions.map((column) => (
+        <RoomCell key={column.id} sessions={day.rooms[column.id] ?? []} />
+      ))}
+    </TableRow>
+  );
+}
+
+interface RoomDayEntry {
+  day: string;
+  isToday: boolean;
+  sessions: RoomSession[];
+}
+
+function RoomDayRows({ entry }: { entry: RoomDayEntry }) {
+  const { day, isToday, sessions } = entry;
+
+  if (!sessions.length) {
+    return (
+      <TableRow className="border-t border-slate-100 text-sm text-slate-600">
+        <TableCell
+          className={cn(
+            "w-40 align-top bg-slate-50 font-semibold text-slate-900",
+            isToday && "bg-amber-100/60 text-amber-900",
+          )}
+        >
+          <div className="flex flex-col gap-1">
+            <span>{day}</span>
+            {isToday ? <TodayBadge /> : null}
+          </div>
+        </TableCell>
+        <TableCell colSpan={3} className="align-top text-sm italic text-slate-400">
+          Aucune surveillance programmée.
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <>
+      {sessions.map((session, index) => {
+        const highlight = getBlockHighlight(session);
+        const variant = getTypeVariant(session.type);
+        return (
+          <TableRow
+            key={`${day}-${index}`}
+            className={cn(
+              "border-t border-slate-100 text-sm text-slate-600",
+              highlight && `${highlight.background} ${highlight.border}`,
+            )}
+          >
+            {index === 0 ? (
+              <TableCell
+                rowSpan={sessions.length}
+                className={cn(
+                  "w-40 align-top bg-slate-50 font-semibold text-slate-900",
+                  isToday && "bg-amber-100/60 text-amber-900",
+                )}
+              >
+                <div className="flex flex-col gap-1">
+                  <span>{day}</span>
+                  {isToday ? <TodayBadge /> : null}
+                </div>
+              </TableCell>
+            ) : null}
+            <TableCell className="align-top">
+              <div className="flex flex-col gap-1">
+                {session.time ? (
+                  <span className="text-sm font-medium text-slate-900">{session.time}</span>
+                ) : (
+                  <span className="text-sm italic text-slate-400">Horaire à confirmer</span>
+                )}
+                {session.label ? <BlockLabel session={session} /> : null}
+              </div>
+            </TableCell>
+            <TableCell className="align-top">
+              {session.teacher ? (
+                <span className={cn("text-sm font-semibold", variant.textColor)}>
+                  {session.teacher}
+                </span>
+              ) : (
+                <span className="text-sm italic text-slate-400">Surveillant à confirmer</span>
+              )}
+            </TableCell>
+            <TableCell className="align-top">
+              <div className="flex items-start gap-2">
+                {session.type ? <TypeBadge type={session.type} compact /> : null}
+                <span className="text-sm text-slate-600">
+                  {session.detail ?? "Détail à préciser"}
+                </span>
+              </div>
+            </TableCell>
+          </TableRow>
+        );
+      })}
+    </>
+  );
+}
+
+function RoomOrganisationCard({
+  room,
+  days,
+}: {
+  room: string;
+  days: RoomDayEntry[];
+}) {
+  const hasContent = days.some((entry) => entry.sessions.length);
+
+  return (
+    <article className="flex h-full flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <header>
+        <h4 className="text-lg font-semibold text-slate-900">{room}</h4>
+        <p className="text-sm text-slate-500">
+          {hasContent
+            ? "Organisation détaillée des surveillances prévues dans cette salle."
+            : "Aucune surveillance n'est planifiée pour cette salle."}
+        </p>
+      </header>
+      <div className="-mx-4 overflow-x-auto px-4">
+        <Table className="min-w-full">
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell scope="col">Jour</TableHeaderCell>
+              <TableHeaderCell scope="col">Créneau</TableHeaderCell>
+              <TableHeaderCell scope="col">Surveillant</TableHeaderCell>
+              <TableHeaderCell scope="col">Épreuve / Détail</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {days.map((entry) => (
+              <RoomDayRows key={entry.day} entry={entry} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </article>
+  );
+}
+
+export default function RoomsStatus() {
+  const { activeView, container } = useDashboardContext();
+  const supportSessions = useMemo(
+    () => buildSupportSessionsByRoom(surveillanceSchedule),
+    [],
+  );
+  const schedule = useMemo<RoomScheduleDay[]>(() => {
+    const baseMap = new Map(roomSchedule.map((day) => [day.day, day] as const));
+    const baseOrder = roomSchedule.map((day) => day.day);
+    const supportOnlyDays = Array.from(supportSessions.keys()).filter(
+      (day) => !baseMap.has(day),
+    );
+    const dayOrder = [...baseOrder, ...supportOnlyDays];
+    return dayOrder.map((dayLabel) => {
+      const baseDay = baseMap.get(dayLabel);
+      const supportForDay = supportSessions.get(dayLabel);
+      const rooms = roomColumns.reduce(
+        (acc, room) => {
+          const baseSessions = baseDay?.rooms[room] ?? [];
+          const extraSessions = supportForDay?.get(room) ?? [];
+          const combined = [...baseSessions, ...extraSessions];
+          combined.sort((a, b) => getSessionSortValue(a) - getSessionSortValue(b));
+          acc[room] = combined;
+          return acc;
+        },
+        {} as Record<RoomColumn, RoomSession[]>,
+      );
+      return { day: dayLabel, rooms } as RoomScheduleDay;
+    });
+  }, [supportSessions]);
+  const perRoomSchedule = useMemo(
+    () =>
+      roomColumnDefinitions.map((column) => ({
+        room: column.label,
+        days: schedule.map((day) => ({
+          day: day.day,
+          isToday: isDayLabelToday(day.day),
+          sessions: day.rooms[column.id] ?? [],
+        })),
+      })),
+    [schedule],
+  );
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(
+    <section
+      id="room-view"
+      data-view-section="room"
+      role="tabpanel"
+      aria-labelledby="room-tab"
+      tabIndex={activeView === "room" ? 0 : -1}
+      aria-hidden={activeView === "room" ? "false" : "true"}
+      className={`${activeView === "room" ? "" : "hidden"} space-y-6`}
+    >
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold text-slate-900">Occupation des salles</h3>
+        <p className="text-sm text-slate-500">
+          Visualisez la disponibilité des salles par créneau pour garantir une répartition fluide des épreuves.
+        </p>
+      </div>
+      <div className="relative rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="overflow-x-auto rounded-xl">
+          <Table className="min-w-[64rem] lg:min-w-full">
+            <TableHead>
+              <TableRow>
+                <TableHeaderCell
+                  scope="col"
+                  className="sticky left-0 z-20 bg-slate-100 px-4 py-3 text-slate-900 shadow-[inset_-16px_0_16px_-16px_rgba(15,23,42,0.3)] sm:px-6"
+                >
+                  Jour
+                </TableHeaderCell>
+                {roomColumnDefinitions.map((column) => (
+                  <TableHeaderCell
+                    key={column.id}
+                    scope="col"
+                    className="min-w-[11rem] whitespace-nowrap px-4 py-3 align-bottom sm:min-w-0 sm:px-6"
+                  >
+                    {column.label}
+                  </TableHeaderCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {schedule.length ? (
+                schedule.map((day) => <RoomRow key={day.day} day={day} />)
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={roomColumns.length + 1} className="text-center text-sm text-slate-500">
+                    Aucune salle programmée pour le moment.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-white to-transparent md:hidden" aria-hidden />
+        <div className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-white to-transparent md:hidden" aria-hidden />
+      </div>
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-slate-900">Organisation détaillée par salle</h3>
+        <p className="text-sm text-slate-500">
+          Retrouvez les missions planifiées, les horaires et les surveillants associés pour chaque salle mobilisée.
+        </p>
+        <div className="grid gap-6 lg:grid-cols-2">
+          {perRoomSchedule.map((room) => (
+            <RoomOrganisationCard key={room.room} room={room.room} days={room.days} />
+          ))}
+        </div>
+      </div>
+    </section>,
+    container,
+  );
+}

--- a/src/features/math-exam-dashboard/components/SurveillanceTable.tsx
+++ b/src/features/math-exam-dashboard/components/SurveillanceTable.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from "react";
+import { createPortal } from "react-dom";
+
+import TodayBadge from "./TodayBadge";
+import TypeBadge from "./TypeBadge";
+import {
+  alertCircleIcon,
+  calendarClockIcon,
+  clipboardListIcon,
+  clock3Icon,
+  mapPinIcon,
+  surveillanceSchedule,
+} from "../data";
+import { useDashboardContext } from "../context";
+import {
+  buildTeacherSchedule,
+  formatDuration,
+  isDatetimeToday,
+  parseDuration,
+  type TeacherScheduleGroup,
+} from "../utils";
+
+const CalendarClockIcon = calendarClockIcon;
+const MapPinIcon = mapPinIcon;
+const Clock3Icon = clock3Icon;
+const ClipboardListIcon = clipboardListIcon;
+const AlertCircleIcon = alertCircleIcon;
+
+function MissionCard({ mission }: { mission: TeacherScheduleGroup["missions"][number] }) {
+  const durationValue = mission.duration
+    ? formatDuration(parseDuration(mission.duration))
+    : "Durée à préciser";
+  const roomContent = mission.room && mission.room.trim() !== "-"
+    ? mission.room
+    : <span className="italic text-slate-400">Salle à confirmer</span>;
+  const isToday = isDatetimeToday(mission.datetime);
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white/80 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-sm font-medium text-slate-700">
+        <div className="flex items-center gap-2 text-slate-600">
+          <CalendarClockIcon className="h-4 w-4" />
+          {isToday ? (
+            <div className="flex items-center gap-2">
+              {mission.datetime}
+              <TodayBadge />
+            </div>
+          ) : (
+            mission.datetime
+          )}
+        </div>
+        <TypeBadge type={mission.type} compact />
+      </div>
+      <p className="mt-2 text-sm font-semibold text-slate-900">{mission.mission}</p>
+      <div className="mt-2 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+        <span className="inline-flex items-center gap-1">
+          <MapPinIcon className="h-3.5 w-3.5" />
+          {roomContent}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Clock3Icon className="h-3.5 w-3.5" />
+          {durationValue}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TeacherCard({ group }: { group: TeacherScheduleGroup }) {
+  const totalSeconds = group.missions.reduce(
+    (sum, mission) => sum + parseDuration(mission.duration),
+    0,
+  );
+  const summary = `${group.missions.length} mission${group.missions.length > 1 ? "s" : ""} • ${formatDuration(totalSeconds)}`;
+  const isUnassigned = group.teacher === "À assigner";
+
+  return (
+    <article className="rounded-xl border border-slate-200 bg-slate-50 p-4 shadow-sm transition hover:shadow">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h4 className="text-lg font-semibold text-slate-900">{group.teacher}</h4>
+          <p className="text-sm text-slate-500">{summary}</p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+            isUnassigned ? "bg-amber-200/80 text-amber-900" : "bg-slate-200/80 text-slate-600"
+          }`}
+        >
+          {isUnassigned ? (
+            <AlertCircleIcon className="h-3.5 w-3.5" />
+          ) : (
+            <ClipboardListIcon className="h-3.5 w-3.5" />
+          )}
+          {isUnassigned ? "Missions en attente d’assignation" : "Planning confirmé"}
+        </span>
+      </div>
+      <div className="mt-4 space-y-3">
+        {group.missions.map((mission, index) => (
+          <MissionCard key={`${group.teacher}-${index}`} mission={mission} />
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export default function SurveillanceTable() {
+  const { activeView, container } = useDashboardContext();
+  const teacherSchedule = useMemo(
+    () => buildTeacherSchedule(surveillanceSchedule),
+    [],
+  );
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(
+    <section
+      id="teacher-view"
+      data-view-section="teacher"
+      role="tabpanel"
+      aria-labelledby="teacher-tab"
+      tabIndex={activeView === "teacher" ? 0 : -1}
+      aria-hidden={activeView === "teacher" ? "false" : "true"}
+      className={`${activeView === "teacher" ? "" : "hidden"} space-y-6`}
+    >
+      <div>
+        <h3 className="text-xl font-semibold text-slate-900">
+          Planning des missions par enseignant
+        </h3>
+        <p className="text-sm text-slate-500">
+          Visualisez le détail des missions pour chaque professeur, avec les horaires, salles et durées totales.
+        </p>
+      </div>
+      {teacherSchedule.length ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {teacherSchedule.map((group) => (
+            <TeacherCard key={group.teacher} group={group} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
+          Aucune mission de surveillance enregistrée pour le moment.
+        </div>
+      )}
+    </section>,
+    container,
+  );
+}

--- a/src/features/math-exam-dashboard/components/TodayBadge.tsx
+++ b/src/features/math-exam-dashboard/components/TodayBadge.tsx
@@ -1,0 +1,12 @@
+import { todayIcon } from "../data";
+
+const TodayIcon = todayIcon;
+
+export default function TodayBadge() {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-900">
+      <TodayIcon className="h-3.5 w-3.5 text-amber-700" />
+      Aujourd'hui
+    </span>
+  );
+}

--- a/src/features/math-exam-dashboard/components/TypeBadge.tsx
+++ b/src/features/math-exam-dashboard/components/TypeBadge.tsx
@@ -1,0 +1,30 @@
+import type { SurveillanceMission } from "../utils";
+import { getTypeVariant } from "../utils";
+
+export default function TypeBadge({
+  type,
+  compact = false,
+}: {
+  type?: SurveillanceMission["type"] | string;
+  compact?: boolean;
+}) {
+  if (!type) {
+    return null;
+  }
+  const variant = getTypeVariant(type);
+  const textClasses = compact
+    ? "text-[10px] font-semibold tracking-wide uppercase"
+    : "text-xs font-semibold";
+  const padding = compact ? "px-2 py-0.5" : "px-2.5 py-1";
+  const Icon = variant.icon;
+  const iconSize = compact ? "h-3 w-3" : "h-3.5 w-3.5";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full ${padding} ${textClasses} ${variant.badgeClasses}`}
+    >
+      <Icon className={`${iconSize} ${variant.iconColor}`} />
+      {variant.label}
+    </span>
+  );
+}

--- a/src/features/math-exam-dashboard/components/index.ts
+++ b/src/features/math-exam-dashboard/components/index.ts
@@ -1,0 +1,13 @@
+export { default as Announcements } from "./Announcements";
+export { default as ConvocationGenerator } from "./ConvocationGenerator";
+export { default as ExamDashboard } from "./ExamDashboard";
+export { default as Header } from "./Header";
+export { default as Hero } from "./Hero";
+export { default as RoomSetup } from "./RoomSetup";
+export { default as RoomsStatus } from "./RoomsStatus";
+export { default as SurveillanceTable } from "./SurveillanceTable";
+export { default as DashboardFooter } from "./Footer";
+export { default as ExamDashboardPageLayout } from "./layout/ExamDashboardPageLayout";
+export { default as TodayBadge } from "./TodayBadge";
+export { default as TypeBadge } from "./TypeBadge";
+export * from "./NavigationButtons";

--- a/src/features/math-exam-dashboard/components/layout/ExamDashboardPageLayout.tsx
+++ b/src/features/math-exam-dashboard/components/layout/ExamDashboardPageLayout.tsx
@@ -1,0 +1,19 @@
+import type { PropsWithChildren, ReactNode } from "react";
+
+interface ExamDashboardPageLayoutProps extends PropsWithChildren {
+  action?: ReactNode;
+}
+
+export default function ExamDashboardPageLayout({
+  children,
+  action,
+}: ExamDashboardPageLayoutProps) {
+  return (
+    <div className="bg-slate-50 text-slate-800">
+      <div className="container mx-auto space-y-8 p-4 sm:p-6 lg:p-8">
+        {action ? <div className="flex justify-end">{action}</div> : null}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/features/math-exam-dashboard/context/dashboard-context.tsx
+++ b/src/features/math-exam-dashboard/context/dashboard-context.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+
+import type { DashboardView } from "./dashboard-utils";
+
+export interface DashboardContextValue {
+  activeView: DashboardView;
+  setActiveView: (view: DashboardView) => void;
+  container: HTMLDivElement | null;
+  setContainer: (node: HTMLDivElement | null) => void;
+}
+
+export const DashboardContext = createContext<DashboardContextValue | null>(null);
+
+export const useDashboardContext = (): DashboardContextValue => {
+  const context = useContext(DashboardContext);
+  if (!context) {
+    throw new Error("Dashboard components must be used within ExamDashboard");
+  }
+  return context;
+};

--- a/src/features/math-exam-dashboard/context/index.ts
+++ b/src/features/math-exam-dashboard/context/index.ts
@@ -1,0 +1,1 @@
+export * from "./dashboard-context";

--- a/src/features/math-exam-dashboard/data/dashboard-data.ts
+++ b/src/features/math-exam-dashboard/data/dashboard-data.ts
@@ -1,0 +1,284 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Calculator,
+  Calendar,
+  CalendarClock,
+  CalendarDays,
+  ClipboardList,
+  Clock,
+  Clock3,
+  Info,
+  LayoutGrid,
+  MapPin,
+  Settings,
+  Sun,
+  UserCheck,
+  Users,
+  Users2,
+} from "lucide-react";
+
+export type TeacherCivility = "Madame" | "Monsieur";
+export type TeacherGender = "female" | "male";
+
+export interface TeacherDirectoryEntry {
+  civility: TeacherCivility;
+  gender: TeacherGender;
+  lastName: string;
+  firstName: string;
+  shortName: string;
+}
+
+type TeacherDirectorySourceEntry = {
+  civility: TeacherCivility;
+  lastName: string;
+  firstName: string;
+};
+
+const normalizeWhitespace = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+const createShortName = (lastName: string, firstName: string): string => {
+  const normalizedLastName = normalizeWhitespace(lastName).toUpperCase();
+  const normalizedFirstName = normalizeWhitespace(firstName);
+  if (!normalizedFirstName) {
+    return normalizedLastName;
+  }
+  const initial = normalizedFirstName.charAt(0).toUpperCase();
+  return `${normalizedLastName} ${initial}.`;
+};
+
+const teacherDirectorySource: TeacherDirectorySourceEntry[] = [
+  { civility: "Madame", lastName: "MICHON GUILLAUME", firstName: "Mathilde" },
+  { civility: "Madame", lastName: "MOURAIN DIOP", firstName: "Fanelly" },
+  { civility: "Monsieur", lastName: "NDOYE", firstName: "Abdoulaye" },
+  { civility: "Monsieur", lastName: "SERVATE", firstName: "Samuel" },
+];
+
+export const teacherDirectory: TeacherDirectoryEntry[] = teacherDirectorySource.map((entry) => {
+  const civility = entry.civility;
+  const gender: TeacherGender = civility === "Madame" ? "female" : "male";
+  const lastName = normalizeWhitespace(entry.lastName).toUpperCase();
+  const firstName = normalizeWhitespace(entry.firstName);
+  return {
+    civility,
+    gender,
+    lastName,
+    firstName,
+    shortName: createShortName(lastName, firstName),
+  };
+});
+
+export const teacherDirectoryByShortName: Record<string, TeacherDirectoryEntry> =
+  teacherDirectory.reduce((acc, entry) => {
+    acc[entry.shortName] = entry;
+    return acc;
+  }, {} as Record<string, TeacherDirectoryEntry>);
+
+export type SurveillanceType = "mathematiques" | "support";
+
+export interface TypeVariant {
+  label: string;
+  icon: LucideIcon;
+  badgeClasses: string;
+  iconColor: string;
+  cardBorder: string;
+  cardBackground: string;
+  textColor: string;
+}
+
+export const typeVariants: Record<string, TypeVariant> = {
+  mathematiques: {
+    label: "Mathématiques",
+    icon: Calculator,
+    badgeClasses: "bg-sky-100 text-sky-800",
+    iconColor: "text-sky-600",
+    cardBorder: "border-sky-200",
+    cardBackground: "bg-white",
+    textColor: "text-sky-900",
+  },
+  support: {
+    label: "Renfort",
+    icon: Users2,
+    badgeClasses: "bg-amber-100 text-amber-800",
+    iconColor: "text-amber-600",
+    cardBorder: "border-amber-200",
+    cardBackground: "bg-amber-50",
+    textColor: "text-amber-800",
+  },
+  default: {
+    label: "Épreuve",
+    icon: CalendarDays,
+    badgeClasses: "bg-slate-100 text-slate-700",
+    iconColor: "text-slate-600",
+    cardBorder: "border-slate-200",
+    cardBackground: "bg-white",
+    textColor: "text-slate-700",
+  },
+};
+
+export interface KeyFigure {
+  value: string;
+  label: string;
+  unit?: string;
+  extra?: string;
+}
+
+export const keyFigures: KeyFigure[] = [
+  { value: "4", label: "Salles mobilisées" },
+  { value: "52", label: "Candidats inscrits" },
+  { value: "09h00", label: "Heure de début", extra: "Accueil des élèves dès 8h30" },
+  { value: "4", unit: "h", label: "Durée de l'épreuve", extra: "Épreuve écrite de mathématiques" },
+];
+
+export interface AccommodationGroup {
+  icon: { Icon: LucideIcon; bg: string; color: string };
+  title: string;
+  description: string;
+  students: string[];
+  note?: string;
+  noteClasses?: string;
+}
+
+export const accommodationGroups: AccommodationGroup[] = [
+  {
+    icon: { Icon: Users2, bg: "bg-emerald-100", color: "text-emerald-600" },
+    title: "Terminale – Aménagements prévus",
+    description: "Élèves bénéficiant d'un tiers temps ou de dispositions particulières :",
+    students: [
+      "À compléter si nécessaire",
+    ],
+    note: "Informer la vie scolaire de tout besoin complémentaire au plus tard le 6 février.",
+    noteClasses: "bg-amber-100/80 text-amber-900",
+  },
+];
+
+export interface SurveillanceMission {
+  teacher: string;
+  datetime: string;
+  room: string;
+  mission: string;
+  duration: string;
+  type: SurveillanceType;
+}
+
+export const surveillanceSchedule: SurveillanceMission[] = [
+  {
+    teacher: "MICHON GUILLAUME M.",
+    datetime: "vendredi 13/02 à 09h00",
+    room: "S14",
+    mission: "Bac blanc de mathématiques",
+    duration: "4:00:00",
+    type: "mathematiques",
+  },
+  {
+    teacher: "MOURAIN DIOP F.",
+    datetime: "vendredi 13/02 à 09h00",
+    room: "S10",
+    mission: "Bac blanc de mathématiques",
+    duration: "4:00:00",
+    type: "mathematiques",
+  },
+  {
+    teacher: "NDOYE A.",
+    datetime: "vendredi 13/02 à 09h00",
+    room: "S11",
+    mission: "Bac blanc de mathématiques",
+    duration: "4:00:00",
+    type: "mathematiques",
+  },
+  {
+    teacher: "SERVATE S.",
+    datetime: "vendredi 13/02 à 09h00",
+    room: "S11 COOP",
+    mission: "Bac blanc de mathématiques",
+    duration: "4:00:00",
+    type: "mathematiques",
+  },
+];
+
+export const roomColumns = ["S10", "S11", "S11 COOP", "S14"] as const;
+
+export type RoomColumn = (typeof roomColumns)[number];
+
+export interface RoomSession {
+  time?: string;
+  teacher?: string;
+  detail?: string;
+  type?: SurveillanceType;
+  label?: string;
+  highlight?: boolean;
+}
+
+export interface RoomScheduleDay {
+  day: string;
+  rooms: Record<RoomColumn, RoomSession[]>;
+}
+
+export const roomSchedule: RoomScheduleDay[] = [
+  {
+    day: "Vendredi 13/02",
+    rooms: {
+      S10: [
+        {
+          time: "09h00 - 13h00",
+          teacher: "MOURAIN DIOP F.",
+          detail: "Mathématiques",
+          type: "mathematiques",
+          highlight: true,
+        },
+      ],
+      S11: [
+        {
+          time: "09h00 - 13h00",
+          teacher: "NDOYE A.",
+          detail: "Mathématiques",
+          type: "mathematiques",
+          highlight: true,
+        },
+      ],
+      "S11 COOP": [
+        {
+          time: "09h00 - 13h00",
+          teacher: "SERVATE S.",
+          detail: "Mathématiques",
+          type: "mathematiques",
+          highlight: true,
+        },
+      ],
+      S14: [
+        {
+          time: "09h00 - 13h00",
+          teacher: "MICHON G. M.",
+          detail: "Mathématiques",
+          type: "mathematiques",
+          highlight: true,
+        },
+      ],
+    },
+  },
+];
+
+export interface DashboardTab {
+  id: "setup" | "teacher" | "convocation" | "room" | "day";
+  label: string;
+  Icon: LucideIcon;
+}
+
+export const dashboardTabs: DashboardTab[] = [
+  { id: "setup", label: "Paramétrage des salles", Icon: Settings },
+  { id: "teacher", label: "Vue par enseignant", Icon: Users },
+  { id: "convocation", label: "Convocations", Icon: ClipboardList },
+  { id: "room", label: "Vue par salle", Icon: LayoutGrid },
+  { id: "day", label: "Vue par jour", Icon: Calendar },
+];
+
+export const infoIcon = Info;
+export const alertTriangleIcon = AlertTriangle;
+export const todayIcon = Sun;
+export const calendarClockIcon = CalendarClock;
+export const mapPinIcon = MapPin;
+export const clock3Icon = Clock3;
+export const clipboardListIcon = ClipboardList;
+export const alertCircleIcon = AlertCircle;
+export const clockIcon = Clock;

--- a/src/features/math-exam-dashboard/data/index.ts
+++ b/src/features/math-exam-dashboard/data/index.ts
@@ -1,0 +1,1 @@
+export * from "./dashboard-data";

--- a/src/features/math-exam-dashboard/hooks/index.ts
+++ b/src/features/math-exam-dashboard/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useDashboardTabs } from "./useDashboardTabs";

--- a/src/features/math-exam-dashboard/hooks/useDashboardTabs.ts
+++ b/src/features/math-exam-dashboard/hooks/useDashboardTabs.ts
@@ -1,0 +1,13 @@
+import { useMemo } from "react";
+
+import { dashboardTabs } from "../data";
+import type { DashboardView } from "../utils";
+
+export default function useDashboardTabs(): {
+  tabs: typeof dashboardTabs;
+  tabIds: DashboardView[];
+} {
+  const tabs = useMemo(() => dashboardTabs, []);
+  const tabIds = useMemo(() => tabs.map(({ id }) => id), [tabs]);
+  return { tabs, tabIds };
+}

--- a/src/features/math-exam-dashboard/index.ts
+++ b/src/features/math-exam-dashboard/index.ts
@@ -1,0 +1,7 @@
+export { default as ExamDashboardPage } from "./pages/ExamDashboardPage";
+export * from "./components";
+export * from "./context";
+export * from "./data";
+export * from "./hooks";
+export * from "./services";
+export * from "./utils";

--- a/src/features/math-exam-dashboard/pages/MathExamDashboardPage.tsx
+++ b/src/features/math-exam-dashboard/pages/MathExamDashboardPage.tsx
@@ -1,0 +1,28 @@
+import {
+  Announcements,
+  BackToHomeButton,
+  ConvocationGenerator,
+  ExamDashboard,
+  ExamDashboardPageLayout,
+  Header,
+  Hero,
+  RoomSetup,
+  RoomsStatus,
+  SurveillanceTable,
+} from "../components";
+
+export default function ExamDashboardPage() {
+  return (
+    <ExamDashboardPageLayout action={<BackToHomeButton />}>
+      <Header />
+      <Hero />
+      <ExamDashboard>
+        <RoomSetup />
+        <SurveillanceTable />
+        <ConvocationGenerator />
+        <RoomsStatus />
+        <Announcements />
+      </ExamDashboard>
+    </ExamDashboardPageLayout>
+  );
+}

--- a/src/features/math-exam-dashboard/services/convocation-pdf.ts
+++ b/src/features/math-exam-dashboard/services/convocation-pdf.ts
@@ -1,0 +1,296 @@
+import html2canvas from "html2canvas";
+import { jsPDF } from "jspdf";
+
+import {
+  formatDuration,
+  parseDuration,
+  type TeacherScheduleGroup,
+} from "../utils";
+import { type TeacherDirectoryEntry, typeVariants } from "../data";
+
+const typeBadgeStyles: Record<string, { background: string; text: string; border: string }> = {
+  mathematiques: {
+    background: "#dbeafe",
+    text: "#1d4ed8",
+    border: "rgba(37, 99, 235, 0.35)",
+  },
+  support: {
+    background: "#fef3c7",
+    text: "#b45309",
+    border: "rgba(217, 119, 6, 0.35)",
+  },
+  default: {
+    background: "#e2e8f0",
+    text: "#1e293b",
+    border: "rgba(100, 116, 139, 0.3)",
+  },
+};
+
+const sanitizeFilename = (value: string): string => {
+  const normalized = value.normalize("NFD").replace(/[^\p{Letter}\p{Number}]+/gu, "-");
+  const trimmed = normalized.replace(/^-+|-+$/g, "");
+  return trimmed.length ? trimmed.toLowerCase() : "convocation";
+};
+
+const createHiddenContainer = (): HTMLDivElement => {
+  const container = document.createElement("div");
+  container.style.position = "absolute";
+  container.style.top = "-10000px";
+  container.style.left = "-10000px";
+  container.style.width = "794px"; // A4 width at ~96 DPI
+  container.style.padding = "48px";
+  container.style.backgroundColor = "#ffffff";
+  container.style.boxSizing = "border-box";
+  container.style.fontFamily = "'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif";
+  container.style.lineHeight = "1.6";
+  container.style.color = "#0f172a";
+  container.style.boxShadow = "0 24px 48px rgba(15, 23, 42, 0.12)";
+  container.style.borderRadius = "16px";
+  container.style.border = "1px solid #e2e8f0";
+  container.style.display = "flex";
+  container.style.flexDirection = "column";
+  container.style.gap = "24px";
+  container.style.textRendering = "optimizeLegibility";
+  return container;
+};
+
+const createSectionTitle = (text: string): HTMLHeadingElement => {
+  const title = document.createElement("h2");
+  title.textContent = text;
+  title.style.fontSize = "20px";
+  title.style.fontWeight = "600";
+  title.style.color = "#1d4ed8";
+  title.style.margin = "0";
+  return title;
+};
+
+const createParagraph = (text: string): HTMLParagraphElement => {
+  const paragraph = document.createElement("p");
+  paragraph.textContent = text;
+  paragraph.style.margin = "0";
+  paragraph.style.fontSize = "14px";
+  paragraph.style.color = "#334155";
+  return paragraph;
+};
+
+const createMissionCard = (
+  mission: TeacherScheduleGroup["missions"][number],
+  index: number,
+): HTMLDivElement => {
+  const card = document.createElement("div");
+  card.style.padding = "16px";
+  card.style.borderRadius = "12px";
+  card.style.border = "1px solid #cbd5f5";
+  card.style.background = "linear-gradient(135deg, #f8fafc, #eef2ff)";
+  card.style.display = "flex";
+  card.style.flexDirection = "column";
+  card.style.gap = "8px";
+
+  const header = document.createElement("div");
+  header.style.display = "flex";
+  header.style.justifyContent = "space-between";
+  header.style.alignItems = "center";
+  header.style.gap = "16px";
+
+  const title = document.createElement("h3");
+  title.style.margin = "0";
+  title.style.fontSize = "16px";
+  title.style.fontWeight = "600";
+  title.style.color = "#1e3a8a";
+  title.textContent = `Mission ${index + 1}`;
+
+  const typeBadge = document.createElement("span");
+  typeBadge.style.display = "inline-flex";
+  typeBadge.style.alignItems = "center";
+  typeBadge.style.padding = "4px 10px";
+  typeBadge.style.borderRadius = "9999px";
+  typeBadge.style.fontSize = "12px";
+  typeBadge.style.fontWeight = "600";
+  typeBadge.style.letterSpacing = "0.02em";
+
+  const variant = typeVariants[mission.type ?? ""] ?? typeVariants.default;
+  const badgeStyle = typeBadgeStyles[mission.type ?? ""] ?? typeBadgeStyles.default;
+  typeBadge.textContent = variant.label;
+  typeBadge.style.backgroundColor = badgeStyle.background;
+  typeBadge.style.color = badgeStyle.text;
+  typeBadge.style.border = `1px solid ${badgeStyle.border}`;
+
+  header.append(title, typeBadge);
+
+  const detailList = document.createElement("ul");
+  detailList.style.margin = "0";
+  detailList.style.padding = "0";
+  detailList.style.listStyle = "none";
+  detailList.style.display = "flex";
+  detailList.style.flexDirection = "column";
+  detailList.style.gap = "4px";
+
+  const createDetailItem = (label: string, value: string): HTMLLIElement => {
+    const item = document.createElement("li");
+    item.style.fontSize = "13px";
+    item.style.color = "#1f2937";
+    item.textContent = `${label} ${value}`;
+    return item;
+  };
+
+  const roomLabel = mission.room && mission.room.trim() !== "-" ? mission.room : "Salle à confirmer";
+  const durationLabel = mission.duration
+    ? formatDuration(parseDuration(mission.duration))
+    : "Durée à préciser";
+
+  detailList.append(
+    createDetailItem("Date et horaire :", mission.datetime ?? "À préciser"),
+    createDetailItem("Salle :", roomLabel),
+    createDetailItem("Épreuve / fonction :", mission.mission ?? "À préciser"),
+    createDetailItem("Durée estimée :", durationLabel),
+  );
+
+  card.append(header, detailList);
+  return card;
+};
+
+const buildConvocationContent = (
+  group: TeacherScheduleGroup,
+  teacherEntry: TeacherDirectoryEntry | undefined,
+): HTMLDivElement => {
+  const container = createHiddenContainer();
+
+  const header = document.createElement("header");
+  header.style.display = "flex";
+  header.style.flexDirection = "column";
+  header.style.gap = "6px";
+
+  const title = document.createElement("h1");
+  title.textContent = "Convocation aux surveillances";
+  title.style.margin = "0";
+  title.style.fontSize = "26px";
+  title.style.fontWeight = "700";
+  title.style.color = "#0f172a";
+
+  const subtitle = document.createElement("p");
+  subtitle.textContent = "Bac blanc de mathématiques – Lycée Français Jacques Prévert de Saly";
+  subtitle.style.margin = "0";
+  subtitle.style.fontSize = "14px";
+  subtitle.style.color = "#475569";
+
+  header.append(title, subtitle);
+
+  const salutation = teacherEntry?.civility ?? "Madame, Monsieur";
+  const teacherName = teacherEntry
+    ? `${teacherEntry.firstName} ${teacherEntry.lastName}`
+    : group.teacher;
+  const invitationSentence = teacherEntry
+    ? teacherEntry.gender === "female"
+      ? "Vous êtes conviée"
+      : "Vous êtes convié"
+    : "Vous êtes convié(e)";
+
+  const introduction = document.createElement("div");
+  introduction.style.display = "flex";
+  introduction.style.flexDirection = "column";
+  introduction.style.gap = "8px";
+
+  introduction.append(
+    createParagraph(`${salutation} ${teacherName},`),
+    createParagraph(
+      `${invitationSentence} à assurer les surveillances suivantes dans le cadre du baccalauréat blanc. ` +
+        "Vous trouverez ci-dessous les informations détaillées pour chaque mission.",
+    ),
+  );
+
+  const missionSection = document.createElement("section");
+  missionSection.style.display = "flex";
+  missionSection.style.flexDirection = "column";
+  missionSection.style.gap = "12px";
+
+  missionSection.append(createSectionTitle("Missions"));
+
+  group.missions.forEach((mission, index) => {
+    missionSection.append(createMissionCard(mission, index));
+  });
+
+  const totalDuration = group.missions.reduce(
+    (sum, mission) => sum + parseDuration(mission.duration),
+    0,
+  );
+
+  const summary = document.createElement("section");
+  summary.style.padding = "18px";
+  summary.style.borderRadius = "12px";
+  summary.style.backgroundColor = "#dbeafe";
+  summary.style.border = "1px solid rgba(37, 99, 235, 0.3)";
+  summary.style.display = "flex";
+  summary.style.flexDirection = "column";
+  summary.style.gap = "6px";
+
+  const summaryTitle = document.createElement("h2");
+  summaryTitle.textContent = "Récapitulatif";
+  summaryTitle.style.margin = "0";
+  summaryTitle.style.fontSize = "18px";
+  summaryTitle.style.fontWeight = "600";
+  summaryTitle.style.color = "#1d4ed8";
+
+  const summaryParagraph = createParagraph(
+    `${group.missions.length} mission${group.missions.length > 1 ? "s" : ""} – Charge totale estimée : ${formatDuration(
+      totalDuration,
+    )}.`,
+  );
+
+  summary.append(summaryTitle, summaryParagraph);
+
+  const closing = document.createElement("p");
+  closing.textContent =
+    "Merci pour votre disponibilité. N'hésitez pas à contacter l'administration en cas de question relative à cette convocation.";
+  closing.style.margin = "0";
+  closing.style.fontSize = "14px";
+  closing.style.color = "#334155";
+
+  container.append(header, introduction, missionSection, summary, closing);
+
+  return container;
+};
+
+export async function downloadConvocationPdf(
+  group: TeacherScheduleGroup,
+  teacherEntry: TeacherDirectoryEntry | undefined,
+): Promise<void> {
+  if (!group || group.missions.length === 0) {
+    throw new Error("Aucune mission sélectionnée");
+  }
+
+  const content = buildConvocationContent(group, teacherEntry);
+  document.body.appendChild(content);
+
+  try {
+    const canvas = await html2canvas(content, {
+      scale: 2,
+      backgroundColor: "#ffffff",
+    });
+    const imgData = canvas.toDataURL("image/png");
+
+    const pdf = new jsPDF({
+      orientation: "portrait",
+      unit: "pt",
+      format: "a4",
+    });
+
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+
+    const renderWidth = canvas.width;
+    const renderHeight = canvas.height;
+    const ratio = Math.min(pageWidth / renderWidth, pageHeight / renderHeight);
+    const width = renderWidth * ratio;
+    const height = renderHeight * ratio;
+    const offsetX = (pageWidth - width) / 2;
+    const offsetY = (pageHeight - height) / 2;
+
+    pdf.addImage(imgData, "PNG", offsetX, offsetY, width, height);
+
+    const filename = `convocation-${sanitizeFilename(group.teacher)}.pdf`;
+    pdf.save(filename);
+  } finally {
+    content.remove();
+  }
+}
+

--- a/src/features/math-exam-dashboard/services/index.ts
+++ b/src/features/math-exam-dashboard/services/index.ts
@@ -1,0 +1,1 @@
+export * from "./convocation-pdf";

--- a/src/features/math-exam-dashboard/utils/dashboard-utils.ts
+++ b/src/features/math-exam-dashboard/utils/dashboard-utils.ts
@@ -1,0 +1,408 @@
+import {
+  type AccommodationGroup,
+  type DashboardTab,
+  type KeyFigure,
+  type RoomColumn,
+  type RoomScheduleDay,
+  type RoomSession,
+  type SurveillanceMission,
+  type TypeVariant,
+  typeVariants,
+} from "../data";
+
+export type DashboardView = DashboardTab["id"];
+
+export interface TeacherScheduleGroup {
+  teacher: string;
+  missions: SurveillanceMission[];
+}
+
+export interface BlockHighlight {
+  background: string;
+  border: string;
+  badgeBackground: string;
+  badgeText: string;
+}
+
+export interface DayScheduleEntry {
+  room: string;
+  teacher?: string;
+  detail?: string;
+  type?: SurveillanceMission["type"];
+  highlight?: boolean | null;
+  time?: string;
+  label?: string;
+}
+
+export interface DaySlot {
+  key: string;
+  time: string | null;
+  label: string | null;
+  entries: DayScheduleEntry[];
+}
+
+export interface DaySchedule {
+  day: string;
+  slots: DaySlot[];
+}
+
+export const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim() !== "";
+
+export const normalizeTeacherName = (name: string): string =>
+  isNonEmptyString(name) ? name.trim() : "À assigner";
+
+const extractTeacherAssignments = (rawTeacher: string): string[] => {
+  const normalizedTeacher = normalizeTeacherName(rawTeacher);
+  const hasMultipleTeachers = rawTeacher.includes(",");
+
+  if (!hasMultipleTeachers) {
+    return [normalizedTeacher];
+  }
+
+  const teacherList = rawTeacher
+    .split(",")
+    .map((entry) => normalizeTeacherName(entry))
+    .filter((entry) => entry !== "À assigner");
+
+  if (!teacherList.length) {
+    return [normalizedTeacher];
+  }
+
+  return Array.from(new Set(teacherList));
+};
+
+export const withFallback = <T>(value: T | null | undefined, fallback: T): T =>
+  value == null || (typeof value === "string" && value === "") ? fallback : value;
+
+export const parseDuration = (duration: string | undefined | null): number => {
+  if (!duration) {
+    return 0;
+  }
+  const [hours = 0, minutes = 0, seconds = 0] = duration.split(":").map(Number);
+  return hours * 3600 + minutes * 60 + seconds;
+};
+
+export const formatDuration = (totalSeconds: number): string => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const parts: string[] = [];
+  if (hours) {
+    parts.push(`${hours}\u202fh`);
+  }
+  if (minutes) {
+    parts.push(`${minutes}\u202fmin`);
+  }
+  return parts.length ? parts.join(" ") : "0 min";
+};
+
+export const getTypeVariant = (type?: string): TypeVariant =>
+  typeVariants[type ?? ""] ?? typeVariants.default;
+
+export const buildTeacherSchedule = (
+  schedule: SurveillanceMission[],
+): TeacherScheduleGroup[] => {
+  const groups = new Map<string, SurveillanceMission[]>();
+  schedule.forEach((mission) => {
+    const teacherAssignments = extractTeacherAssignments(mission.teacher);
+
+    teacherAssignments.forEach((teacher) => {
+      const current = groups.get(teacher) ?? [];
+      current.push({ ...mission, teacher });
+      groups.set(teacher, current);
+    });
+  });
+
+  return Array.from(groups.entries())
+    .map(([teacher, missions]) => ({ teacher, missions }))
+    .sort((a, b) => {
+      if (a.teacher === "À assigner") {
+        return 1;
+      }
+      if (b.teacher === "À assigner") {
+        return -1;
+      }
+      return a.teacher.localeCompare(b.teacher, "fr", { sensitivity: "base" });
+    });
+};
+
+const extractStartHour = (time: string | null | undefined): number | null => {
+  if (!time) {
+    return null;
+  }
+  const match = time.match(/(\d{1,2})h/);
+  if (!match) {
+    return null;
+  }
+  return Number(match[1]);
+};
+
+const capitalizeWord = (value: string): string => {
+  if (!isNonEmptyString(value)) {
+    return value;
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+};
+
+export const getBlockHighlight = (
+  session: Pick<RoomSession, "label" | "time">,
+): BlockHighlight | null => {
+  const normalizedLabel = withFallback(session.label, "").toLowerCase();
+  const startHour = extractStartHour(session.time);
+  if (normalizedLabel.includes("matin") || (startHour !== null && startHour < 12)) {
+    return {
+      background: "bg-sky-50",
+      border: "border-sky-200",
+      badgeBackground: "bg-sky-200/70",
+      badgeText: "text-sky-900",
+    };
+  }
+  if (
+    normalizedLabel.includes("après") ||
+    normalizedLabel.includes("apres") ||
+    (startHour !== null && startHour >= 12)
+  ) {
+    return {
+      background: "bg-rose-50",
+      border: "border-rose-200",
+      badgeBackground: "bg-rose-200/70",
+      badgeText: "text-rose-900",
+    };
+  }
+  return null;
+};
+
+const parseDayParts = (label: string): { day: number; month: number } | null => {
+  const match = label.match(/(\d{1,2})\/(\d{1,2})/);
+  if (!match) {
+    return null;
+  }
+  return { day: Number(match[1]), month: Number(match[2]) };
+};
+
+const parseDatetimeParts = (datetime: string): { day: number; month: number } | null =>
+  parseDayParts(datetime);
+
+const isTodayFromParts = (parts: { day: number; month: number } | null): boolean => {
+  if (!parts) {
+    return false;
+  }
+  const now = new Date();
+  return now.getDate() === parts.day && now.getMonth() + 1 === parts.month;
+};
+
+export const isDayLabelToday = (label: string): boolean =>
+  isTodayFromParts(parseDayParts(label));
+
+export const isDatetimeToday = (datetime: string): boolean =>
+  isTodayFromParts(parseDatetimeParts(datetime));
+
+interface SupportMissionEntry {
+  dayLabel: string;
+  timeRange: string | null;
+  teacher: string;
+  detail: string;
+  type: SurveillanceMission["type"];
+  roomLabel: string;
+  blockLabel: string;
+  rooms: RoomColumn[];
+}
+
+const supportRoomNumberMap: Record<string, RoomColumn> = {
+  "9": "S9 PRIO / EPS",
+  "10": "S10",
+  "12": "S12",
+  "13": "S13",
+  "14": "S14",
+  "15": "S15",
+  "16": "S16",
+};
+
+const extractSupportRooms = (value: string): RoomColumn[] => {
+  if (!isNonEmptyString(value)) {
+    return [];
+  }
+  const matches = value.match(/\d{1,2}/g);
+  if (!matches) {
+    return [];
+  }
+  return matches
+    .map((match) => supportRoomNumberMap[match])
+    .filter((room): room is RoomColumn => Boolean(room));
+};
+
+const parseSupportMission = (
+  mission: SurveillanceMission,
+): SupportMissionEntry | null => {
+  if (mission.type !== "support" || !isNonEmptyString(mission.datetime)) {
+    return null;
+  }
+  const match = mission.datetime.match(
+    /([A-Za-zÀ-ÿ]+)\s+(\d{1,2}\/\d{1,2})\s+à\s+(\d{1,2})h(\d{2})/i,
+  );
+  if (!match) {
+    return null;
+  }
+  const [, rawDayName, datePart, hourPart, minutePart] = match;
+  const startHour = hourPart.padStart(2, "0");
+  const startMinute = minutePart.padStart(2, "0");
+  const dayLabel = `${capitalizeWord(rawDayName)} ${datePart}`;
+  const startTime = `${startHour}h${startMinute}`;
+  const durationSeconds = parseDuration(mission.duration);
+  let endTime: string | null = null;
+  if (durationSeconds) {
+    const startTotalMinutes = Number(startHour) * 60 + Number(startMinute);
+    const endTotalMinutes = startTotalMinutes + Math.round(durationSeconds / 60);
+    const endHour = Math.floor(endTotalMinutes / 60);
+    const endMinute = endTotalMinutes % 60;
+    endTime = `${String(endHour).padStart(2, "0")}h${String(endMinute).padStart(2, "0")}`;
+  }
+  const timeRange = endTime ? `${startTime} - ${endTime}` : startTime;
+  return {
+    dayLabel,
+    timeRange,
+    teacher: normalizeTeacherName(mission.teacher),
+    detail: mission.mission,
+    type: mission.type,
+    roomLabel: "Support",
+    blockLabel: "Support",
+    rooms: extractSupportRooms(mission.room),
+  };
+};
+
+export const buildDaySchedule = (
+  schedule: RoomScheduleDay[],
+  missions: SurveillanceMission[],
+): DaySchedule[] => {
+  const dayMap = new Map<string, { day: string; slots: DaySlot[]; slotMap: Map<string, DaySlot> }>();
+  const dayOrder: string[] = [];
+
+  const ensureDayEntry = (day: string) => {
+    if (!dayMap.has(day)) {
+      dayMap.set(day, { day, slots: [], slotMap: new Map() });
+      dayOrder.push(day);
+    }
+    return dayMap.get(day)!;
+  };
+
+  const addSlotEntry = (
+    day: string,
+    slotKey: { key: string; time: string | null; label: string | null },
+    entry: DayScheduleEntry,
+  ) => {
+    const dayEntry = ensureDayEntry(day);
+    if (!dayEntry.slotMap.has(slotKey.key)) {
+      const slot: DaySlot = {
+        key: slotKey.key,
+        time: slotKey.time,
+        label: slotKey.label,
+        entries: [],
+      };
+      dayEntry.slotMap.set(slotKey.key, slot);
+      dayEntry.slots.push(slot);
+    }
+    dayEntry.slotMap.get(slotKey.key)!.entries.push(entry);
+  };
+
+  schedule.forEach(({ day, rooms }) => {
+    (Object.entries(rooms) as [string, RoomSession[]][]).forEach(([room, sessions]) => {
+      sessions.forEach((session) => {
+        const key = session.time ?? session.label ?? "Horaire à confirmer";
+        addSlotEntry(
+          day,
+          { key, time: session.time ?? null, label: session.label ?? null },
+          {
+            room,
+            teacher: session.teacher,
+            detail: session.detail,
+            type: session.type,
+            highlight: session.highlight ?? null,
+            time: session.time,
+            label: session.label,
+          },
+        );
+      });
+    });
+  });
+
+  missions
+    .map(parseSupportMission)
+    .filter((entry): entry is SupportMissionEntry => Boolean(entry))
+    .forEach((support) => {
+      const key = support.timeRange ?? support.blockLabel ?? "Support";
+      addSlotEntry(
+        support.dayLabel,
+        { key, time: support.timeRange, label: support.blockLabel },
+        {
+          room: support.roomLabel,
+          teacher: support.teacher,
+          detail: support.detail,
+          type: support.type,
+          highlight: null,
+          time: support.timeRange ?? undefined,
+          label: support.blockLabel,
+        },
+      );
+    });
+
+  return dayOrder.map((day) => {
+    const { slots } = dayMap.get(day)!;
+    slots.sort((a, b) => {
+      const hourA = extractStartHour(a.time);
+      const hourB = extractStartHour(b.time);
+      if (hourA !== null && hourB !== null) {
+        return hourA - hourB;
+      }
+      if (hourA !== null) {
+        return -1;
+      }
+      if (hourB !== null) {
+        return 1;
+      }
+      return withFallback(a.label, "").localeCompare(withFallback(b.label, ""), "fr", {
+        sensitivity: "base",
+      });
+    });
+    return { day, slots };
+  });
+};
+
+export const buildSupportSessionsByRoom = (
+  missions: SurveillanceMission[],
+): Map<string, Map<RoomColumn, RoomSession[]>> => {
+  const supportSessions = new Map<string, Map<RoomColumn, RoomSession[]>>();
+
+  missions
+    .map(parseSupportMission)
+    .filter((entry): entry is SupportMissionEntry => Boolean(entry))
+    .forEach((entry) => {
+      if (!entry.rooms.length) {
+        return;
+      }
+      const daySessions = supportSessions.get(entry.dayLabel) ?? new Map<RoomColumn, RoomSession[]>();
+      entry.rooms.forEach((room) => {
+        const sessions = daySessions.get(room) ?? [];
+        sessions.push({
+          time: entry.timeRange ?? undefined,
+          teacher: entry.teacher,
+          detail: entry.detail,
+          type: entry.type,
+          label: entry.blockLabel,
+        });
+        daySessions.set(room, sessions);
+      });
+      supportSessions.set(entry.dayLabel, daySessions);
+    });
+
+  return supportSessions;
+};
+
+export type {
+  AccommodationGroup,
+  DashboardTab,
+  KeyFigure,
+  RoomScheduleDay,
+  RoomSession,
+  SurveillanceMission,
+  TypeVariant,
+};

--- a/src/features/math-exam-dashboard/utils/index.ts
+++ b/src/features/math-exam-dashboard/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./dashboard-utils";


### PR DESCRIPTION
## Summary
- duplicate the dashboard feature to serve a dedicated bac blanc de mathématiques view with tailored data, layouts and convocation templates for 13 February 2026
- wire the new dashboard into the router and surface it from the home page alongside the December session entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd56cce2bc8331856def648f00c9dd