### PR TITLE
Fix dashboard context imports

### DIFF
--- a/src/features/exam-dashboard/context/dashboard-context.tsx
+++ b/src/features/exam-dashboard/context/dashboard-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-import type { DashboardView } from "./dashboard-utils";
+import type { DashboardView } from "../utils";
 
 export interface DashboardContextValue {
   activeView: DashboardView;

--- a/src/features/math-exam-dashboard/context/dashboard-context.tsx
+++ b/src/features/math-exam-dashboard/context/dashboard-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-import type { DashboardView } from "./dashboard-utils";
+import type { DashboardView } from "../utils";
 
 export interface DashboardContextValue {
   activeView: DashboardView;


### PR DESCRIPTION
## Summary
- update both dashboard contexts to import `DashboardView` from the shared utils barrel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd83aa60e08331b66a0fc51b84322b