### PR TITLE
Corriger incohérences sur les plannings et données des bacs blancs

### DIFF
--- a/src/features/exam-dashboard/context/dashboard-context.tsx
+++ b/src/features/exam-dashboard/context/dashboard-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-import type { DashboardView } from "./dashboard-utils";
+import type { DashboardView } from "../utils";
 
 export interface DashboardContextValue {
   activeView: DashboardView;

--- a/src/features/exam-dashboard/data/dashboard-data.ts
+++ b/src/features/exam-dashboard/data/dashboard-data.ts
@@ -77,7 +77,7 @@ const teacherDirectorySource: TeacherDirectorySourceEntry[] = [
   { civility: "Monsieur", lastName: "FRAYON", firstName: "Antoine" },
   { civility: "Madame", lastName: "GIBUS", firstName: "Amandine" },
   { civility: "Monsieur", lastName: "GOMIS", firstName: "Alain" },
-  { civility: "Monsieur", lastName: "JAÏT", firstName: "Layla" },
+  { civility: "Madame", lastName: "JAÏT", firstName: "Layla" },
   { civility: "Madame", lastName: "JENOUDET", firstName: "Sandra" },
   { civility: "Madame", lastName: "KREMER", firstName: "Laurence" },
   { civility: "Madame", lastName: "KUNTZ", firstName: "Emilie" },

--- a/src/features/exam-dashboard/services/convocation-pdf.ts
+++ b/src/features/exam-dashboard/services/convocation-pdf.ts
@@ -181,7 +181,8 @@ const buildConvocationContent = (
   title.style.color = "#0f172a";
 
   const subtitle = document.createElement("p");
-  subtitle.textContent = "Baccalauréat blanc – Lycée Français Jean-Paul";
+  subtitle.textContent =
+    "Baccalauréat blanc – Lycée Français Jacques Prévert de Saly";
   subtitle.style.margin = "0";
   subtitle.style.fontSize = "14px";
   subtitle.style.color = "#475569";

--- a/src/features/exam-dashboard/utils/dashboard-utils.ts
+++ b/src/features/exam-dashboard/utils/dashboard-utils.ts
@@ -211,6 +211,7 @@ interface SupportMissionEntry {
 const supportRoomNumberMap: Record<string, RoomColumn> = {
   "9": "S9 PRIO / EPS",
   "10": "S10",
+  "11": "S11",
   "12": "S12",
   "13": "S13",
   "14": "S14",

--- a/src/features/math-exam-dashboard/context/dashboard-context.tsx
+++ b/src/features/math-exam-dashboard/context/dashboard-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-import type { DashboardView } from "./dashboard-utils";
+import type { DashboardView } from "../utils";
 
 export interface DashboardContextValue {
   activeView: DashboardView;

--- a/src/features/math-exam-dashboard/data/datasets/math-2026-02-13.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-02-13.ts
@@ -126,7 +126,7 @@ export const mathExamDashboardData20260213: MathExamDashboardData = {
   roomSchedule,
   examRooms: [
     { name: "S10", examCapacity: 13 },
-    { name: "S11", examCapacity: 15 },
+    { name: "S12", examCapacity: 13 },
     { name: "S11 COOP", examCapacity: 12 },
     { name: "S14", examCapacity: 12 },
   ],

--- a/src/features/math-exam-dashboard/data/datasets/math-2026-05-23.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-05-23.ts
@@ -14,7 +14,7 @@ const teacherDirectory = createTeacherDirectory([
 
 const roomSchedule: RoomScheduleDay[] = [
   {
-    day: "Vendredi 22/05",
+    day: "Samedi 23/05",
     rooms: {
       S10: [
         {
@@ -59,7 +59,7 @@ const roomSchedule: RoomScheduleDay[] = [
 export const mathExamDashboardData20260523: MathExamDashboardData = {
   header: {
     title: "Bac blanc de mathématiques 1ère",
-    date: "Vendredi 22 mai 2026 • 11h10",
+    date: "Samedi 23 mai 2026 • 11h10",
   },
   keyFigures: [
     { value: "4", label: "Salles mobilisées" },
@@ -91,7 +91,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
   surveillanceSchedule: [
     {
       teacher: "CAPEL E.",
-      datetime: "vendredi 22/05 à 11h10",
+      datetime: "samedi 23/05 à 11h10",
       room: "S15",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",
@@ -99,7 +99,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
     },
     {
       teacher: "FRAYON A.",
-      datetime: "vendredi 22/05 à 11h10",
+      datetime: "samedi 23/05 à 11h10",
       room: "S13",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",
@@ -107,7 +107,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
     },
     {
       teacher: "NDOYE A.",
-      datetime: "vendredi 22/05 à 11h10",
+      datetime: "samedi 23/05 à 11h10",
       room: "S14",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",
@@ -115,7 +115,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
     },
     {
       teacher: "SERVATE S.",
-      datetime: "vendredi 22/05 à 11h10",
+      datetime: "samedi 23/05 à 11h10",
       room: "S10",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",

--- a/src/features/math-exam-dashboard/utils/dashboard-utils.ts
+++ b/src/features/math-exam-dashboard/utils/dashboard-utils.ts
@@ -212,6 +212,7 @@ interface SupportMissionEntry {
 const supportRoomNumberMap: Record<string, RoomColumn> = {
   "9": "S9 PRIO / EPS",
   "10": "S10",
+  "11": "S11",
   "12": "S12",
   "13": "S13",
   "14": "S14",


### PR DESCRIPTION
## Summary
- corriger l’importation du type `DashboardView` dans les contextes des tableaux de bord
- ajouter la salle 11 aux mappings des missions de renfort et rectifier les données des plannings mathématiques
- mettre à jour la civilité de Layla JAÏT et le sous-titre des convocations PDF

## Testing
- npm run build *(échoue : `vite` introuvable avant installation des dépendances)*
- npm install *(échoue : conflit de dépendances `eslint` / `@typescript-eslint/eslint-plugin`)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8b024fcc8331ad1f8bf0aff56120