### PR TITLE
Fix missing Terminale accommodations in April bac blanc dashboard

### DIFF
--- a/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
+++ b/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
@@ -353,6 +353,8 @@ export const bacBlancEAFDashboardData20260407: MathExamDashboardData = {
         "RISPAL Charlie",
         "NDOUR Fatou",
         "SOBLOG Oscar",
+        "FALL CLAMENS Omar",
+        "ZARB Frédy",
       ],
       note: "Informer la vie scolaire de tout besoin complémentaire avant le 3 avril.",
       noteClasses: "bg-amber-100/70 text-amber-900",


### PR DESCRIPTION
## Summary
- add the two missing Terminale students to the April bac blanc accommodations list

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea792ba1883319e944009ff03a13b