### PR TITLE
Retire les notes d'accompagnement du bac blanc EAF

### DIFF
--- a/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
+++ b/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
@@ -354,8 +354,6 @@ export const bacBlancEAFDashboardData20260407: MathExamDashboardData = {
         "NDOUR Fatou",
         "SOBLOG Oscar",
       ],
-      note: "Informer la vie scolaire de tout besoin complémentaire avant le 3 avril.",
-      noteClasses: "bg-amber-100/70 text-amber-900",
     },
     {
       icon: { Icon: BookOpen, bg: "bg-sky-100", color: "text-sky-700" },
@@ -366,8 +364,6 @@ export const bacBlancEAFDashboardData20260407: MathExamDashboardData = {
         "SARR Sokhna Faty",
         "KERDUDO Zeina",
       ],
-      note: "Derniers justificatifs attendus pour finalisation le 28 mars.",
-      noteClasses: "bg-blue-100/70 text-blue-900",
     },
   ],
   teacherDirectory,


### PR DESCRIPTION
## Summary
- retire les notes d'information des groupes d'aménagements pour ne plus afficher les encarts jaunes et bleus

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dea7fa59748331b479a1c860fde459