### PR TITLE
Sort exam callouts by date and differentiate icons

### DIFF
--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -12,54 +12,76 @@ export const HOME_PAGE_CONTENT = {
     "Cet espace réunit l'ensemble des informations pratiques nécessaires pour préparer, coordonner et faire vivre les épreuves. Vous y trouverez les documents, convocations, affectations de salles et les consignes indispensables pour guider sereinement chaque étape du déroulement des examens blancs.",
 };
 
-export const HOME_DASHBOARD_ENTRY = {
+export type HomeCalloutCategory = "general" | "math";
+
+export interface HomeCalloutEntry {
+  to: string;
+  iconLabel: string;
+  subtitle: string;
+  title: string;
+  dateLabel: string;
+  date: string;
+  description: string;
+  footerLabel: string;
+  category: HomeCalloutCategory;
+}
+
+export const HOME_DASHBOARD_ENTRY: HomeCalloutEntry = {
   to: "/examens-blancs",
   iconLabel: "Accéder à l'organisation des examens blancs",
   subtitle: "",
   title: "Baccalauréat blanc 1ère et Terminale",
   dateLabel: "10, 11 et 12 décembre 2025",
+  date: "2025-12-10",
   description:
     "Cliquez pour accéder à la préparation détaillée des épreuves, aux répartitions des salles et aux outils pédagogiques.",
-  footerLabel: "Découvrir l'organisation",
+  footerLabel: "Accéder à l'organisation complète",
+  category: "general",
 };
 
-export const HOME_MATH_EXAM_20260213_ENTRY = {
+export const HOME_MATH_EXAM_20260213_ENTRY: HomeCalloutEntry = {
   to: "/examens-blancs/mathematiques-2026-02-13",
   iconLabel: "Consulter l'organisation du bac blanc de mathématiques",
   subtitle: "",
   title: "Bac blanc de mathématiques",
   dateLabel: "13 février 2026",
+  date: "2026-02-13",
   description:
     "Accédez à la répartition des salles, aux convocations et aux informations pratiques pour l'épreuve de mathématiques.",
-  footerLabel: "Voir le planning",
+  footerLabel: "Accéder à l'organisation complète",
+  category: "math",
 };
 
-export const HOME_MATH_EXAM_20260523_ENTRY = {
+export const HOME_MATH_EXAM_20260523_ENTRY: HomeCalloutEntry = {
   to: "/examens-blancs/mathematiques-2026-05-23",
   iconLabel: "Consulter l'organisation du bac blanc de mathématiques 1ère",
   subtitle: "",
   title: "Bac blanc de mathématiques 1ère",
   dateLabel: "23 mai 2026",
+  date: "2026-05-23",
   description:
     "Toutes les affectations de salles, convocations et consignes pour l'épreuve de mathématiques des classes de 1ère.",
-  footerLabel: "Découvrir l'organisation",
+  footerLabel: "Accéder à l'organisation complète",
+  category: "math",
 };
 
-export const HOME_EAF_EXAM_20260407_ENTRY = {
+export const HOME_EAF_EXAM_20260407_ENTRY: HomeCalloutEntry = {
   to: "/examens-blancs/eaf-2026-04-07",
   iconLabel: "Consulter l'organisation du bac blanc EAF",
   subtitle: "",
   title: "Bac blanc EAF 1re & Terminale",
   dateLabel: "7 au 10 avril 2026",
+  date: "2026-04-07",
   description:
     "Accédez aux répartitions, convocations et consignes pour les épreuves de français, philosophie et spécialités.",
-  footerLabel: "Voir l'organisation détaillée",
+  footerLabel: "Accéder à l'organisation complète",
+  category: "general",
 };
 
-export const HOME_CALLOUT_ENTRIES = [
+export const HOME_CALLOUT_ENTRIES: HomeCalloutEntry[] = [
   HOME_DASHBOARD_ENTRY,
   HOME_MATH_EXAM_20260213_ENTRY,
-  HOME_MATH_EXAM_20260523_ENTRY,
   HOME_EAF_EXAM_20260407_ENTRY,
+  HOME_MATH_EXAM_20260523_ENTRY,
 ];
 

--- a/src/features/home/pages/HomePage.tsx
+++ b/src/features/home/pages/HomePage.tsx
@@ -1,12 +1,22 @@
-import { CalendarDays, GraduationCap } from "lucide-react";
+import { CalendarDays, Calculator, GraduationCap } from "lucide-react";
 
 import HomeCallToActionCard from "../components/HomeCallToActionCard";
 import HomeEventMeta from "../components/HomeEventMeta";
 import HomeHero from "../components/HomeHero";
 import HomeLayout from "../components/HomeLayout";
+import type { HomeCalloutEntry } from "../constants";
 import { HOME_CALLOUT_ENTRIES, HOME_PAGE_CONTENT } from "../constants";
 
 export default function HomePage() {
+  const calloutEntries = [...HOME_CALLOUT_ENTRIES].sort((a, b) =>
+    new Date(a.date).getTime() - new Date(b.date).getTime(),
+  );
+
+  const iconByCategory: Record<HomeCalloutEntry["category"], typeof GraduationCap> = {
+    general: GraduationCap,
+    math: Calculator,
+  };
+
   return (
     <HomeLayout>
       <HomeHero
@@ -17,19 +27,22 @@ export default function HomePage() {
       />
 
       <div className="grid w-full max-w-4xl grid-cols-1 gap-6 lg:grid-cols-2">
-        {HOME_CALLOUT_ENTRIES.map((entry) => (
-          <HomeCallToActionCard
-            key={entry.to}
-            to={entry.to}
-            icon={GraduationCap}
-            iconLabel={entry.iconLabel}
-            subtitle={entry.subtitle}
-            title={entry.title}
-            description={entry.description}
-            footerLabel={entry.footerLabel}
-            meta={<HomeEventMeta icon={CalendarDays} label={entry.dateLabel} description="" />}
-          />
-        ))}
+        {calloutEntries.map((entry) => {
+          const Icon = iconByCategory[entry.category];
+          return (
+            <HomeCallToActionCard
+              key={entry.to}
+              to={entry.to}
+              icon={Icon}
+              iconLabel={entry.iconLabel}
+              subtitle={entry.subtitle}
+              title={entry.title}
+              description={entry.description}
+              footerLabel={entry.footerLabel}
+              meta={<HomeEventMeta icon={CalendarDays} label={entry.dateLabel} description="" />}
+            />
+          );
+        })}
       </div>
     </HomeLayout>
   );


### PR DESCRIPTION
## Summary
- add metadata to home callout entries so they can be sorted chronologically and share consistent link labels
- render home page callout cards with date-based ordering and category-specific icons for math versus other exams

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deaa39acfc8331a7aa5dc5c28fcea3