### PR TITLE
Clarify April mock exam schedule

### DIFF
--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -73,7 +73,7 @@ export const HOME_EAF_EXAM_20260407_ENTRY: HomeCalloutEntry = {
   dateLabel: "7 au 10 avril 2026",
   date: "2026-04-07",
   description:
-    "Accédez aux répartitions, convocations et consignes pour les épreuves de français, philosophie et spécialités.",
+    "Accédez aux répartitions, convocations et consignes : mardi EAF (1re), mercredi philosophie (Terminale), jeudi spécialité n°1, vendredi spécialité n°2.",
   footerLabel: "Accéder à l'organisation complète",
   category: "general",
 };

--- a/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
+++ b/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
@@ -326,7 +326,8 @@ export const bacBlancEAFDashboardData20260407: MathExamDashboardData = {
   header: {
     title: "Bac blanc EAF – 1re et Terminale",
     date: "Du mardi 7 au vendredi 10 avril 2026",
-    subtitle: "Sessions de français, philosophie et spécialités",
+    subtitle:
+      "Mardi : EAF (1re) · Mercredi : Philosophie (Terminale) · Jeudi : Spécialité n°1 · Vendredi : Spécialité n°2",
   },
   keyFigures: [
     { value: "6", label: "Salles mobilisées" },


### PR DESCRIPTION
## Summary
- clarify the April mock exam callout description with the daily schedule for EAF, philosophy and specialties
- update the EAF dashboard header subtitle to highlight the exam sequence from Tuesday to Friday

## Testing
- npm run lint *(fails: missing eslint.config.js in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68deab26e3588331bfa818f84cd380c9