### PR TITLE
Ajoute les échéances de reprographie pour les examens blancs

### DIFF
--- a/src/features/exam-dashboard/components/Header.tsx
+++ b/src/features/exam-dashboard/components/Header.tsx
@@ -1,3 +1,5 @@
+import { CalendarClock } from "lucide-react";
+
 export default function Header() {
   return (
     <header className="space-y-4">
@@ -19,6 +21,10 @@ export default function Header() {
         </div>
       </div>
       <p className="text-lg text-slate-600">10, 11 et 12 Décembre 2025</p>
+      <div className="flex items-center gap-3 text-sm text-slate-600 sm:text-base">
+        <CalendarClock className="h-5 w-5 text-slate-500" aria-hidden="true" />
+        <span>Transmission des sujets à la direction avant le 1er décembre 2025 pour reprographie.</span>
+      </div>
     </header>
   );
 }

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -21,6 +21,8 @@ export interface HomeCalloutEntry {
   title: string;
   dateLabel: string;
   date: string;
+  deadlineLabel: string;
+  deadlineDate: string;
   description: string;
   footerLabel: string;
   category: HomeCalloutCategory;
@@ -33,6 +35,8 @@ export const HOME_DASHBOARD_ENTRY: HomeCalloutEntry = {
   title: "Baccalauréat blanc 1ère et Terminale",
   dateLabel: "10, 11 et 12 décembre 2025",
   date: "2025-12-10",
+  deadlineLabel: "1er décembre 2025",
+  deadlineDate: "2025-12-01",
   description:
     "Cliquez pour accéder à la préparation détaillée des épreuves, aux répartitions des salles et aux outils pédagogiques.",
   footerLabel: "Accéder à l'organisation complète",
@@ -46,6 +50,8 @@ export const HOME_MATH_EXAM_20260213_ENTRY: HomeCalloutEntry = {
   title: "Bac blanc de mathématiques",
   dateLabel: "13 février 2026",
   date: "2026-02-13",
+  deadlineLabel: "6 février 2026",
+  deadlineDate: "2026-02-06",
   description:
     "Accédez à la répartition des salles, aux convocations et aux informations pratiques pour l'épreuve de mathématiques.",
   footerLabel: "Accéder à l'organisation complète",
@@ -59,6 +65,8 @@ export const HOME_MATH_EXAM_20260523_ENTRY: HomeCalloutEntry = {
   title: "Bac blanc de mathématiques 1ère",
   dateLabel: "23 mai 2026",
   date: "2026-05-23",
+  deadlineLabel: "15 mai 2026",
+  deadlineDate: "2026-05-15",
   description:
     "Toutes les affectations de salles, convocations et consignes pour l'épreuve de mathématiques des classes de 1ère.",
   footerLabel: "Accéder à l'organisation complète",
@@ -72,6 +80,8 @@ export const HOME_EAF_EXAM_20260407_ENTRY: HomeCalloutEntry = {
   title: "Baccalauréat blanc 1ère et Terminale",
   dateLabel: "7 au 10 avril 2026",
   date: "2026-04-07",
+  deadlineLabel: "24 mars 2026",
+  deadlineDate: "2026-03-24",
   description:
     "Cliquez pour accéder à la préparation détaillée des épreuves, aux répartitions des salles et aux consignes : mardi EAF (1re), mercredi philosophie (Terminale), jeudi spécialité n°1, vendredi spécialité n°2.",
   footerLabel: "Accéder à l'organisation complète",

--- a/src/features/home/pages/HomePage.tsx
+++ b/src/features/home/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, Calculator, GraduationCap } from "lucide-react";
+import { CalendarClock, CalendarDays, Calculator, GraduationCap } from "lucide-react";
 
 import HomeCallToActionCard from "../components/HomeCallToActionCard";
 import HomeEventMeta from "../components/HomeEventMeta";
@@ -39,7 +39,16 @@ export default function HomePage() {
               title={entry.title}
               description={entry.description}
               footerLabel={entry.footerLabel}
-              meta={<HomeEventMeta icon={CalendarDays} label={entry.dateLabel} description="" />}
+              meta={
+                <div className="space-y-2 text-left">
+                  <HomeEventMeta icon={CalendarDays} label={entry.dateLabel} description="" />
+                  <HomeEventMeta
+                    icon={CalendarClock}
+                    label={`Sujets à transmettre avant le ${entry.deadlineLabel}`}
+                    description="Direction & reprographie"
+                  />
+                </div>
+              }
             />
           );
         })}

--- a/src/features/math-exam-dashboard/components/Header.tsx
+++ b/src/features/math-exam-dashboard/components/Header.tsx
@@ -1,3 +1,5 @@
+import { CalendarClock } from "lucide-react";
+
 import { useMathExamData } from "../context";
 
 export default function Header() {
@@ -21,6 +23,14 @@ export default function Header() {
         </div>
       </div>
       <p className="text-lg text-slate-600">{header.date}</p>
+      {header.reprographyDeadline ? (
+        <div className="flex items-center gap-3 text-sm text-slate-600 sm:text-base">
+          <CalendarClock className="h-5 w-5 text-slate-500" aria-hidden="true" />
+          <span>
+            Transmission des sujets à la direction avant le {header.reprographyDeadline.label} pour reprographie.
+          </span>
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
+++ b/src/features/math-exam-dashboard/data/datasets/eaf-2026-04-07.ts
@@ -328,6 +328,10 @@ export const bacBlancEAFDashboardData20260407: MathExamDashboardData = {
     date: "Du mardi 7 au vendredi 10 avril 2026",
     subtitle:
       "Mardi : EAF (1re) · Mercredi : Philosophie (Terminale) · Jeudi : Spécialité n°1 · Vendredi : Spécialité n°2",
+    reprographyDeadline: {
+      label: "24 mars 2026",
+      date: "2026-03-24",
+    },
   },
   keyFigures: [
     { value: "6", label: "Salles mobilisées" },

--- a/src/features/math-exam-dashboard/data/datasets/math-2026-02-13.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-02-13.ts
@@ -60,6 +60,10 @@ export const mathExamDashboardData20260213: MathExamDashboardData = {
   header: {
     title: "Bac blanc de mathématiques",
     date: "Vendredi 13 février 2026 • 09h00",
+    reprographyDeadline: {
+      label: "6 février 2026",
+      date: "2026-02-06",
+    },
   },
   keyFigures: [
     { value: "4", label: "Salles mobilisées" },

--- a/src/features/math-exam-dashboard/data/datasets/math-2026-05-23.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-05-23.ts
@@ -60,6 +60,10 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
   header: {
     title: "Bac blanc de mathématiques 1ère",
     date: "Samedi 23 mai 2026 • 11h10",
+    reprographyDeadline: {
+      label: "15 mai 2026",
+      date: "2026-05-15",
+    },
   },
   keyFigures: [
     { value: "4", label: "Salles mobilisées" },

--- a/src/features/math-exam-dashboard/data/types.ts
+++ b/src/features/math-exam-dashboard/data/types.ts
@@ -91,6 +91,10 @@ export interface MathExamDashboardData {
     title: string;
     date: string;
     subtitle?: string;
+    reprographyDeadline?: {
+      date: string;
+      label: string;
+    };
   };
   keyFigures: KeyFigure[];
   accommodationGroups: AccommodationGroup[];


### PR DESCRIPTION
## Summary
- ajoute une date limite de transmission des sujets pour chaque examen blanc sur la page d’accueil
- affiche les rappels d’échéance dans les en-têtes des tableaux de bord généraux et spécifiques
- enregistre les nouvelles échéances dans les jeux de données des examens

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec21dc6948331a41b757868c4d43b