### PR TITLE
Update exam footers with reprography deadlines

### DIFF
--- a/src/features/exam-dashboard/components/Footer.tsx
+++ b/src/features/exam-dashboard/components/Footer.tsx
@@ -3,8 +3,9 @@ export default function Footer() {
     <footer className="rounded-lg bg-blue-100 p-4 text-center text-blue-800">
       <p className="font-semibold">Rappel :</p>
       <p>
-        Envoi des sujets au moins une semaine avant le bac blanc. Présence des
-        surveillants 20 min avant le début de l'épreuve.
+        Envoi des sujets au plus tard le 1er décembre 2025, comme indiqué dans
+        l'en-tête. Présence des surveillants 20 min avant le début de
+        l'épreuve.
       </p>
     </footer>
   );

--- a/src/features/math-exam-dashboard/components/Footer.tsx
+++ b/src/features/math-exam-dashboard/components/Footer.tsx
@@ -1,10 +1,16 @@
+import { useMathExamData } from "../context";
+
 export default function Footer() {
+  const { header } = useMathExamData();
+  const reprographyDeadlineLabel = header.reprographyDeadline?.label;
+
   return (
     <footer className="rounded-lg bg-blue-100 p-4 text-center text-blue-800">
       <p className="font-semibold">Rappel :</p>
       <p>
-        Merci de transmettre les sujets au plus tard le 6 février et d'être
-        présents 20 min avant le début de l'épreuve.
+        {reprographyDeadlineLabel
+          ? `Merci de transmettre les sujets au plus tard le ${reprographyDeadlineLabel} et d'être présents 20 min avant le début de l'épreuve.`
+          : "Merci de transmettre les sujets dans les délais de reprographie communiqués et d'être présents 20 min avant le début de l'épreuve."}
       </p>
     </footer>
   );

--- a/src/features/math-exam-dashboard/data/datasets/math-2026-02-13.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-02-13.ts
@@ -60,6 +60,9 @@ export const mathExamDashboardData20260213: MathExamDashboardData = {
   header: {
     title: "Bac blanc de mathématiques",
     date: "Vendredi 13 février 2026 • 09h00",
+    reprographyDeadline: {
+      label: "Vendredi 6 février 2026",
+    },
   },
   keyFigures: [
     { value: "4", label: "Salles mobilisées" },

--- a/src/features/math-exam-dashboard/data/datasets/math-2026-05-23.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-05-23.ts
@@ -60,6 +60,9 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
   header: {
     title: "Bac blanc de mathématiques 1ère",
     date: "Samedi 23 mai 2026 • 11h10",
+    reprographyDeadline: {
+      label: "Mardi 19 mai 2026",
+    },
   },
   keyFigures: [
     { value: "4", label: "Salles mobilisées" },

--- a/src/features/math-exam-dashboard/data/types.ts
+++ b/src/features/math-exam-dashboard/data/types.ts
@@ -91,6 +91,9 @@ export interface MathExamDashboardData {
     title: string;
     date: string;
     subtitle?: string;
+    reprographyDeadline?: {
+      label: string;
+    };
   };
   keyFigures: KeyFigure[];
   accommodationGroups: AccommodationGroup[];


### PR DESCRIPTION
## Summary
- align the general exam dashboard footer with the December 1, 2025 reprography deadline while keeping the surveillance reminder
- expose reprography deadline metadata in math dashboard data and surface it in the footer with a fallback message
- populate reprography deadlines for the February and May 2026 math exam datasets

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dec5fffb5c833182cd3fddcf598b90