### PR TITLE
Add Grand Oral Blanc (2026-04-17) planning page with exports and home entry

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -23,6 +23,9 @@ const OralEafExam202604Page = lazy(
 const DnbZaoExam202602Page = lazy(
   () => import("../features/math-exam-dashboard/pages/DnbZaoExam202602Page"),
 );
+const GrandOralExam20260417Page = lazy(
+  () => import("../features/grand-oral-exam-202604/pages/GrandOralExam20260417Page"),
+);
 
 export default function App() {
   return (
@@ -53,6 +56,10 @@ export default function App() {
         <Route
           path="/examens-blancs/dnb-blanc-zao-2026-02-03"
           element={<DnbZaoExam202602Page />}
+        />
+        <Route
+          path="/examens-blancs/grand-oral-2026-04-17"
+          element={<GrandOralExam20260417Page />}
         />
       </Routes>
     </Suspense>

--- a/src/features/grand-oral-exam-202604/data/candidates.ts
+++ b/src/features/grand-oral-exam-202604/data/candidates.ts
@@ -1,0 +1,65 @@
+export interface GrandOralCandidate {
+  candidate: string;
+  className: string;
+  date: string;
+  convocationTime: string;
+  examTime: string;
+  juryExpert: string;
+  juryNaif: string;
+  room: string;
+}
+
+const EXAM_DATE = "2026-04-17";
+const CLASS_NAME = "Terminale";
+
+export const grandOralCandidates20260417: GrandOralCandidate[] = [
+  { candidate: "BRUNIE Sarah Amandine", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "08:00", examTime: "08:20", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "GALAND Aurélien", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "08:00", examTime: "08:20", juryExpert: "M. FALL", juryNaif: "Mme JAÏT", room: "14" },
+  { candidate: "BA Khalifa Ababacar", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "08:00", examTime: "08:20", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "KOUROUMA Bakary", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "08:30", examTime: "08:50", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "MBOW Ramatoulaye", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "08:30", examTime: "08:50", juryExpert: "M. FALL", juryNaif: "Mme JAÏT", room: "14" },
+  { candidate: "BASTIDE AHMED Malik", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "08:30", examTime: "08:50", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "MAREGA Yssa Naman", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "09:00", examTime: "09:20", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "MERDJANOPOULOS Louka Jeff Gérard", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "09:00", examTime: "09:20", juryExpert: "M. FALL", juryNaif: "Mme JAÏT", room: "14" },
+  { candidate: "BELKHAYAT ZOUKKARI Mouna", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "09:00", examTime: "09:20", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "MESSINA--EMIEUX Tom", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "09:30", examTime: "09:50", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "RISPAL Charlie", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "09:30", examTime: "09:50", juryExpert: "M. FALL", juryNaif: "Mme JAÏT", room: "14" },
+  { candidate: "BUOVOLO Mariam", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "09:30", examTime: "09:50", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "MINGOU Cécilia Rita", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "10:00", examTime: "10:20", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "RAGUIN Kesya Marème Thérèse", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "10:00", examTime: "10:20", juryExpert: "M. FALL", juryNaif: "Mme JAÏT", room: "14" },
+  { candidate: "CISSE Combe", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "10:00", examTime: "10:20", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "MOUABE Aaron Stephane", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "10:30", examTime: "10:50", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "ZARB Frédy", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "10:30", examTime: "10:50", juryExpert: "M. FALL", juryNaif: "Mme JAÏT", room: "14" },
+  { candidate: "DJOUKWE David Levi", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "10:30", examTime: "10:50", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "N'JAMBONG Asaja-Samba", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "11:00", examTime: "11:20", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "NIANG Papa Ibrahima Cheikh", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "11:00", examTime: "11:20", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "NDOUR Fatou", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "11:30", examTime: "11:50", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "SIDHOUM Anas", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "11:30", examTime: "11:50", juryExpert: "M. NDOYE", juryNaif: "Mme MICHON-GUILLAUME", room: "12" },
+  { candidate: "SON Ye Seon", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "12:00", examTime: "12:20", juryExpert: "M. ANE", juryNaif: "Mme MBOUP", room: "15" },
+  { candidate: "BARIC Yerim Cyprien", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "13:00", examTime: "13:20", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "ARRON Hélène", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "13:00", examTime: "13:20", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "ABOUDOU AMOUSSA Inès Naïmatou Olayémi", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "13:00", examTime: "13:20", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "BRARD Louka", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "13:30", examTime: "13:50", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "BABO Yanis Christopher Gnezebo", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "13:30", examTime: "13:50", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "ACETO NDIAYE Awa", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "13:30", examTime: "13:50", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "GAZI Ethan Charles", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "14:00", examTime: "14:20", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "DANCOING Louna Amina", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "14:00", examTime: "14:20", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "APACK Nayla Marie", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "14:00", examTime: "14:20", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "LANZETTI Luigi", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "14:30", examTime: "14:50", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "FALL Djellya Yacine", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "14:30", examTime: "14:50", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "CERNEJESKI Hugo", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "14:30", examTime: "14:50", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "MBOUP Mame Diarra", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "15:00", examTime: "15:20", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "JACOBE Lou", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "15:00", examTime: "15:20", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "CISSE Ibrahima", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "15:00", examTime: "15:20", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "NDAW Mary Louise Yacine", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "15:30", examTime: "15:50", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "PERINER Angie Michelle Ruby", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "15:30", examTime: "15:50", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "DE GAIGNERON JOLLIMON DE MAROLLES Philippine Sabine Marie", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "15:30", examTime: "15:50", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "NGOM Khadija", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "16:00", examTime: "16:20", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "SOBLOG Oscar Jephte Joseph", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "16:00", examTime: "16:20", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "FALL CLAMENS Omar Louis", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "16:00", examTime: "16:20", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "ROWLAND Noah Dilhane", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "16:30", examTime: "16:50", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "SOW Diye", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "16:30", examTime: "16:50", juryExpert: "Mme MBOUP", juryNaif: "M. NDOYE", room: "14" },
+  { candidate: "MONTMASSON Helena Amy", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "16:30", examTime: "16:50", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+  { candidate: "SOW Aminata Soraya", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "17:00", examTime: "17:20", juryExpert: "Mme JAÏT", juryNaif: "M. FAYE", room: "15" },
+  { candidate: "WONE Fatimata", className: CLASS_NAME, date: EXAM_DATE, convocationTime: "17:00", examTime: "17:20", juryExpert: "Mme MICHON-GUILLAUME", juryNaif: "M. FALL", room: "12" },
+];

--- a/src/features/grand-oral-exam-202604/pages/GrandOralExam20260417Page.tsx
+++ b/src/features/grand-oral-exam-202604/pages/GrandOralExam20260417Page.tsx
@@ -1,0 +1,416 @@
+import { Fragment, useMemo, useState } from "react";
+import { Download, FileText } from "lucide-react";
+import { jsPDF } from "jspdf";
+
+import { BackToHomeButton, ExamDashboardPageLayout } from "../../exam-dashboard/components";
+import { Table, TableBody, TableCell, TableHead, TableHeaderCell, TableRow } from "../../../shared/components";
+import { cn } from "../../../shared/lib";
+import type { GrandOralCandidate } from "../data/candidates";
+import { grandOralCandidates20260417 } from "../data/candidates";
+
+const tabs = [
+  { id: "overview", label: "Organisation complète" },
+  { id: "jury", label: "Planning par jury" },
+  { id: "room", label: "Planning par salle" },
+] as const;
+
+type TabId = (typeof tabs)[number]["id"];
+
+const fullDateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+
+function formatDate(isoDate: string): string {
+  return fullDateFormatter.format(new Date(`${isoDate}T00:00:00`));
+}
+
+function toCsvValue(value: string | number): string {
+  const stringValue = String(value ?? "").replace(/\r?\n/g, " ");
+
+  if (/[";\n]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+}
+
+function downloadCsv(filename: string, rows: Array<Array<string | number>>): void {
+  const csvContent = rows.map((row) => row.map(toCsvValue).join(";")).join("\n");
+  const blob = new Blob(["\uFEFF", csvContent], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+}
+
+interface PdfColumn {
+  header: string;
+  widthRatio: number;
+}
+
+function downloadPlanningPdf(filename: string, title: string, subtitle: string, columns: PdfColumn[], rows: string[][]): void {
+  const doc = new jsPDF({ unit: "pt", format: "a4", orientation: "landscape" });
+  const marginX = 36;
+  const marginY = 52;
+  const usableWidth = doc.internal.pageSize.getWidth() - marginX * 2;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const columnWidths = columns.map((column) => column.widthRatio * usableWidth);
+
+  const drawHeader = (y: number): number => {
+    const headerHeight = 24;
+    let x = marginX;
+
+    doc.setFillColor(15, 23, 42);
+    doc.setTextColor(255, 255, 255);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(10);
+
+    columns.forEach((column, index) => {
+      const width = columnWidths[index];
+      doc.rect(x, y, width, headerHeight, "F");
+      doc.text(column.header, x + 6, y + 16);
+      x += width;
+    });
+
+    return y + headerHeight;
+  };
+
+  const drawRows = (startY: number) => {
+    let y = startY;
+
+    rows.forEach((row, rowIndex) => {
+      const lineHeight = 12;
+      const rowPadding = 6;
+      const splitCells = row.map((value, index) => doc.splitTextToSize(value, Math.max(columnWidths[index] - 12, 30)));
+      const maxLines = Math.max(...splitCells.map((cell) => cell.length || 1));
+      const rowHeight = maxLines * lineHeight + rowPadding * 2;
+
+      if (y + rowHeight > pageHeight - marginY) {
+        doc.addPage();
+        y = drawHeader(marginY);
+      }
+
+      let x = marginX;
+      splitCells.forEach((cell, index) => {
+        const width = columnWidths[index];
+        doc.setFillColor(rowIndex % 2 === 0 ? 248 : 255, rowIndex % 2 === 0 ? 250 : 255, rowIndex % 2 === 0 ? 252 : 255);
+        doc.rect(x, y, width, rowHeight, "F");
+        doc.setDrawColor(226, 232, 240);
+        doc.rect(x, y, width, rowHeight);
+
+        doc.setFont("helvetica", "normal");
+        doc.setFontSize(9);
+        doc.setTextColor(15, 23, 42);
+
+        let textY = y + rowPadding + lineHeight;
+        cell.forEach((line) => {
+          doc.text(line, x + 6, textY);
+          textY += lineHeight;
+        });
+        x += width;
+      });
+
+      y += rowHeight;
+    });
+  };
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(16);
+  doc.setTextColor(15, 23, 42);
+  doc.text(title, marginX, marginY - 16);
+
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(11);
+  doc.setTextColor(71, 85, 105);
+  doc.text(subtitle, marginX, marginY);
+
+  const tableStartY = drawHeader(marginY + 16);
+  drawRows(tableStartY);
+
+  doc.save(filename);
+}
+
+function getJuryPair(candidate: GrandOralCandidate): string {
+  return `${candidate.juryExpert} / ${candidate.juryNaif}`;
+}
+
+function toFilenameSlug(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .slice(0, 60);
+}
+
+function sortCandidates(candidates: GrandOralCandidate[]): GrandOralCandidate[] {
+  return [...candidates].sort((a, b) => {
+    const convocationDiff = a.convocationTime.localeCompare(b.convocationTime);
+    if (convocationDiff !== 0) {
+      return convocationDiff;
+    }
+    return a.candidate.localeCompare(b.candidate);
+  });
+}
+
+function groupBy<T>(items: T[], keyGetter: (item: T) => string): Array<{ key: string; items: T[] }> {
+  const map = new Map<string, T[]>();
+
+  items.forEach((item) => {
+    const key = keyGetter(item);
+    const previous = map.get(key);
+    if (previous) {
+      previous.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  });
+
+  return Array.from(map.entries()).map(([key, groupedItems]) => ({ key, items: groupedItems }));
+}
+
+interface CandidateTableProps {
+  candidates: GrandOralCandidate[];
+  showRoom?: boolean;
+  showJuryPair?: boolean;
+}
+
+function CandidateTable({ candidates, showRoom = false, showJuryPair = false }: CandidateTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <Table className="min-w-full divide-y divide-slate-200">
+        <TableHead>
+          <TableRow className="bg-slate-100">
+            <TableHeaderCell>Nom du candidat</TableHeaderCell>
+            <TableHeaderCell>Classe</TableHeaderCell>
+            <TableHeaderCell>Convocation</TableHeaderCell>
+            <TableHeaderCell>Passage</TableHeaderCell>
+            <TableHeaderCell>Jury expert</TableHeaderCell>
+            <TableHeaderCell>Jury naïf</TableHeaderCell>
+            {showJuryPair ? <TableHeaderCell>Binôme</TableHeaderCell> : null}
+            {showRoom ? <TableHeaderCell>Salle</TableHeaderCell> : null}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {candidates.map((candidate) => (
+            <TableRow key={`${candidate.candidate}-${candidate.convocationTime}-${candidate.room}`}>
+              <TableCell className="font-medium text-slate-900">{candidate.candidate}</TableCell>
+              <TableCell>{candidate.className}</TableCell>
+              <TableCell>{candidate.convocationTime}</TableCell>
+              <TableCell>{candidate.examTime}</TableCell>
+              <TableCell>{candidate.juryExpert}</TableCell>
+              <TableCell>{candidate.juryNaif}</TableCell>
+              {showJuryPair ? <TableCell>{getJuryPair(candidate)}</TableCell> : null}
+              {showRoom ? <TableCell>Salle {candidate.room}</TableCell> : null}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export default function GrandOralExam20260417Page() {
+  const [activeTab, setActiveTab] = useState<TabId>("overview");
+
+  const sortedCandidates = useMemo(() => sortCandidates(grandOralCandidates20260417), []);
+  const candidatesByJuryPair = useMemo(() => groupBy(sortedCandidates, getJuryPair), [sortedCandidates]);
+  const candidatesByRoom = useMemo(() => groupBy(sortedCandidates, (candidate) => candidate.room), [sortedCandidates]);
+
+  const uniqueRooms = new Set(sortedCandidates.map((candidate) => candidate.room)).size;
+  const uniqueJuryPairs = candidatesByJuryPair.length;
+
+  return (
+    <ExamDashboardPageLayout action={<BackToHomeButton />}>
+      <div className="space-y-10">
+        <header className="space-y-4 rounded-3xl bg-white p-6 shadow-sm sm:p-10">
+          <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-slate-600">
+            Grand Oral Blanc — Terminale
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">Organisation du Grand Oral Blanc — vendredi 17 avril 2026</h1>
+            <p className="max-w-3xl text-lg text-slate-600">
+              Planning détaillé des convocations avec jurys expert/naïf, horaires de passage et salles.
+            </p>
+          </div>
+          <dl className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              <dt className="text-sm font-semibold uppercase tracking-wide text-slate-500">Date</dt>
+              <dd className="mt-1 text-lg font-semibold text-slate-900">{formatDate("2026-04-17")}</dd>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              <dt className="text-sm font-semibold uppercase tracking-wide text-slate-500">Candidats</dt>
+              <dd className="mt-1 text-3xl font-bold text-slate-900">{sortedCandidates.length}</dd>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              <dt className="text-sm font-semibold uppercase tracking-wide text-slate-500">Jurys / salles</dt>
+              <dd className="mt-1 text-lg font-semibold text-slate-900">{uniqueJuryPairs} binômes · {uniqueRooms} salles</dd>
+            </div>
+          </dl>
+        </header>
+
+        <nav className="flex flex-wrap gap-2 rounded-2xl bg-white p-2 shadow-sm" aria-label="Navigation des onglets">
+          {tabs.map((tab) => {
+            const isActive = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={cn(
+                  "rounded-xl px-4 py-2 text-sm font-semibold transition",
+                  isActive ? "bg-slate-900 text-white" : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+                )}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </nav>
+
+        {activeTab === "overview" ? <CandidateTable candidates={sortedCandidates} showRoom /> : null}
+
+        {activeTab === "jury" ? (
+          <section className="space-y-8">
+            {candidatesByJuryPair.map(({ key, items }) => {
+              const rows = items.map((candidate) => [
+                candidate.candidate,
+                candidate.className,
+                candidate.convocationTime,
+                candidate.examTime,
+                candidate.juryExpert,
+                candidate.juryNaif,
+                `Salle ${candidate.room}`,
+              ]);
+
+              return (
+                <div key={key} className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Binôme de jury</p>
+                      <h2 className="text-2xl font-bold text-slate-900">{key}</h2>
+                      <p className="text-sm text-slate-600">{items.length} candidats</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => downloadCsv(`planning-jury-${toFilenameSlug(key)}.csv`, [["Nom", "Classe", "Convocation", "Passage", "Jury expert", "Jury naïf", "Salle"], ...rows])}
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                      >
+                        <Download className="h-4 w-4" aria-hidden="true" />
+                        CSV
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          downloadPlanningPdf(
+                            `planning-jury-${toFilenameSlug(key)}.pdf`,
+                            `Grand Oral Blanc — Jury ${key}`,
+                            `Vendredi 17 avril 2026 · ${items.length} candidats`,
+                            [
+                              { header: "Nom", widthRatio: 0.31 },
+                              { header: "Classe", widthRatio: 0.1 },
+                              { header: "Convocation", widthRatio: 0.1 },
+                              { header: "Passage", widthRatio: 0.1 },
+                              { header: "Jury expert", widthRatio: 0.13 },
+                              { header: "Jury naïf", widthRatio: 0.13 },
+                              { header: "Salle", widthRatio: 0.13 },
+                            ],
+                            rows,
+                          )
+                        }
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                      >
+                        <FileText className="h-4 w-4" aria-hidden="true" />
+                        PDF
+                      </button>
+                    </div>
+                  </header>
+                  <CandidateTable candidates={items} showRoom />
+                </div>
+              );
+            })}
+          </section>
+        ) : null}
+
+        {activeTab === "room" ? (
+          <section className="space-y-8">
+            {candidatesByRoom.map(({ key, items }) => {
+              const rows = items.map((candidate) => [
+                candidate.candidate,
+                candidate.className,
+                candidate.convocationTime,
+                candidate.examTime,
+                candidate.juryExpert,
+                candidate.juryNaif,
+              ]);
+
+              return (
+                <div key={key} className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Salle</p>
+                      <h2 className="text-2xl font-bold text-slate-900">Salle {key}</h2>
+                      <p className="text-sm text-slate-600">{items.length} candidats</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => downloadCsv(`planning-salle-${key}.csv`, [["Nom", "Classe", "Convocation", "Passage", "Jury expert", "Jury naïf"], ...rows])}
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                      >
+                        <Download className="h-4 w-4" aria-hidden="true" />
+                        CSV
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          downloadPlanningPdf(
+                            `planning-salle-${key}.pdf`,
+                            `Grand Oral Blanc — Salle ${key}`,
+                            `Vendredi 17 avril 2026 · ${items.length} candidats`,
+                            [
+                              { header: "Nom", widthRatio: 0.36 },
+                              { header: "Classe", widthRatio: 0.1 },
+                              { header: "Convocation", widthRatio: 0.12 },
+                              { header: "Passage", widthRatio: 0.12 },
+                              { header: "Jury expert", widthRatio: 0.15 },
+                              { header: "Jury naïf", widthRatio: 0.15 },
+                            ],
+                            rows,
+                          )
+                        }
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                      >
+                        <FileText className="h-4 w-4" aria-hidden="true" />
+                        PDF
+                      </button>
+                    </div>
+                  </header>
+                  <div className="space-y-6">
+                    {groupBy(items, (candidate) => getJuryPair(candidate)).map(({ key: pairKey, items: pairItems }) => (
+                      <Fragment key={pairKey}>
+                        <h3 className="text-lg font-semibold text-slate-900">{pairKey}</h3>
+                        <CandidateTable candidates={pairItems} />
+                      </Fragment>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+        ) : null}
+      </div>
+    </ExamDashboardPageLayout>
+  );
+}

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -91,6 +91,17 @@ export const HOME_EAF_ORAL_202605_ENTRY: HomeCalloutEntry = {
   category: "oral",
 };
 
+export const HOME_GRAND_ORAL_20260417_ENTRY: HomeCalloutEntry = {
+  to: "/examens-blancs/grand-oral-2026-04-17",
+  iconLabel: "Consulter l'organisation du Grand Oral Blanc",
+  subtitle: "",
+  title: "Grand Oral Blanc",
+  dateLabel: "Vendredi 17 avril 2026",
+  date: "2026-04-17",
+  footerLabel: "Accéder au planning détaillé",
+  category: "oral",
+};
+
 export const HOME_DNB_ZAO_202602_ENTRY: HomeCalloutEntry = {
   to: "/examens-blancs/dnb-blanc-zao-2026-02-03",
   iconLabel: "Organisation du DNB blanc",
@@ -108,7 +119,7 @@ export const HOME_CALLOUT_ENTRIES: HomeCalloutEntry[] = [
   HOME_MATH_EXAM_20260213_ENTRY,
   HOME_EAF_EXAM_20260407_ENTRY,
   HOME_EAF_ORAL_202604_ENTRY,
+  HOME_GRAND_ORAL_20260417_ENTRY,
   HOME_EAF_ORAL_202605_ENTRY,
   HOME_MATH_EXAM_20260523_ENTRY,
 ];
-


### PR DESCRIPTION
### Motivation
- Provide a dedicated planning view for the Grand Oral Blanc (Terminale) on 17 April 2026 so staff can consult convocations, juries and room assignments and export schedules.

### Description
- Add candidate data and type in `src/features/grand-oral-exam-202604/data/candidates.ts` exposing `grandOralCandidates20260417` and `GrandOralCandidate`.
- Implement the planning UI in `src/features/grand-oral-exam-202604/pages/GrandOralExam20260417Page.tsx` with tabbed views (`overview`, `jury`, `room`), sorted/grouped lists, table rendering and utilities for CSV and PDF export (`downloadCsv`, `downloadPlanningPdf`).
- Register the new route in `src/app/App.tsx` and add a home callout entry `HOME_GRAND_ORAL_20260417_ENTRY` in `src/features/home/constants.ts` so the page is reachable from the homepage.
- Reuse existing shared components and layout (`Table`, `ExamDashboardPageLayout`, `BackToHomeButton`) and add helpers for formatting, slug generation and grouping.

### Testing
- Ran TypeScript type checking (`tsc`) against the project and it succeeded.
- Executed the project test suite (`yarn test`) and it passed.
- Built the application (`yarn build`) to verify bundling after the change and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e8effa288331aba089ce764d5e68)