### PR TITLE
Réduire la taille du cachet sur les convocations de surveillance

### DIFF
--- a/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
+++ b/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
@@ -162,7 +162,7 @@ function buildPrintDocument(title: string, content: string) {
   .presence { background: #fef2f2; color: #dc2626; font-weight: 700; }
   .signatures { margin-top: 22px; padding-top: 12px; display: flex; justify-content: space-between; gap: 20px; }
   .signatures p { font-size: 12px; color: #64748b; text-align: center; }
-  .signatures img { height: 96px; object-fit: contain; }
+  .signatures img { height: 72px; max-width: 160px; object-fit: contain; }
   .line { width: 230px; border-bottom: 1px solid #9ca3af; margin: 50px auto 0; }
   @media print { @page { margin: 1.5cm; } body { padding: 0; } }
 </style>


### PR DESCRIPTION
### Motivation
- Réduire l'empreinte visuelle du cachet (proviseur) sur les convocations pour mieux coller au modèle d'origine et éviter une signature trop dominante.

### Description
- Modifie le CSS dans `src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx` en remplaçant `height: 96px` par `height: 72px` et en ajoutant `max-width: 160px` sur la règle `.signatures img` pour contraindre la taille du cachet.

### Testing
- `npm ci --legacy-peer-deps` a été exécuté avec succès.
- `npm run build` a été exécuté avec succès après l'installation des dépendances; une exécution initiale de `npm run build` avait échoué précédemment car `vite` n'était pas installé (`vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4023cd55083319e80ae5d647533f9)