### PR TITLE
Update convocations CTA wording for oral exam pages

### DIFF
--- a/src/features/french-oral-exam-202604/pages/OralEafExam202604Page.tsx
+++ b/src/features/french-oral-exam-202604/pages/OralEafExam202604Page.tsx
@@ -510,7 +510,7 @@ export default function OralEafExam202604Page() {
                   rel="noreferrer"
                   className="inline-flex w-full items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
                 >
-                  Accéder aux convocations
+                  Accéder aux convocations des élèves
                 </a>
               </aside>
             </div>

--- a/src/features/french-oral-exam-202605/pages/OralEafExam202605Page.tsx
+++ b/src/features/french-oral-exam-202605/pages/OralEafExam202605Page.tsx
@@ -571,7 +571,7 @@ export default function OralEafExam202605Page() {
                   rel="noreferrer"
                   className="inline-flex w-full items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
                 >
-                  Accéder aux convocations
+                  Accéder aux convocations des élèves
                 </a>
               </aside>
             </div>


### PR DESCRIPTION
### Motivation
- Harmoniser le libellé du bouton pour préciser qu'il s'agit des convocations des élèves afin d'améliorer la clarté de l'interface utilisateur.
- Appliquer la même formulation sur les pages des deux sessions pour garantir une cohérence entre `202604` et `202605`.

### Description
- Remplacé le texte `Accéder aux convocations` par `Accéder aux convocations des élèves` dans `src/features/french-oral-exam-202604/pages/OralEafExam202604Page.tsx`.
- Effectué le même changement dans `src/features/french-oral-exam-202605/pages/OralEafExam202605Page.tsx`.

### Testing
- Lancé `npm run lint`, qui a échoué à cause de l'absence d'un fichier de configuration plat ESLint (`eslint.config.*`) requis par ESLint v9.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4951d82e883318471b47cf87e8cdd)