### PR TITLE
fix: restore convocation stamp signature asset

### DIFF
--- a/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
+++ b/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
@@ -16,7 +16,7 @@ import { jsPDF } from "jspdf";
 
 const A4_WIDTH_PX = 794;
 const A4_HEIGHT_PX = 1123;
-const STAMP_IMAGE_SRC = "/cachet-proviseur.svg";
+const STAMP_IMAGE_SRC = "https://i.imgur.com/77DP4od.png";
 const HTML2CANVAS_OPTIONS = {
   scale: 1.5,
   backgroundColor: "#ffffff",


### PR DESCRIPTION
## Summary
- reverted the convocation signature stamp source in `BacDnbSurveillancePage` to the previously working image asset
- replaced the local SVG reference with the known-good PNG URL used before the latest signature change

## Why
The latest signature update caused the stamp to render incorrectly in the convocation preview (partial/cropped shape). This change restores the expected signature display.

## Testing
- Not run (static change only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61e7ad99c83318d278c4f3895bcd1)