### PR TITLE
Use externally hosted proviseur stamp and increase stamp display size

### DIFF
--- a/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
+++ b/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
@@ -16,7 +16,7 @@ import { jsPDF } from "jspdf";
 
 const A4_WIDTH_PX = 794;
 const A4_HEIGHT_PX = 1123;
-const STAMP_IMAGE_SRC = "/cachet-proviseur.svg";
+const STAMP_IMAGE_SRC = "https://i.imgur.com/77DP4od.png";
 const HTML2CANVAS_OPTIONS = {
   scale: 1.5,
   backgroundColor: "#ffffff",
@@ -153,7 +153,7 @@ function ConvocationSheet({ supervisor, bacShifts, dnbShifts, showSignatureBlock
             <img
               src={STAMP_IMAGE_SRC}
               alt="Cachet du Proviseur"
-              className="mx-auto h-[72px] max-w-[160px] object-contain"
+              className="mx-auto h-[88px] max-w-[200px] object-contain"
             />
           </div>
           <div className="space-y-2 text-center">


### PR DESCRIPTION
### Motivation
- Ensure the proviseur stamp is available to `html2canvas`/PDF export and make the visible stamp slightly larger for printed convocations.  

### Description
- Replace the local `STAMP_IMAGE_SRC` value with an externally hosted URL and increase the stamp image dimensions in the convocation signature block (`h-[72px]` → `h-[88px]`, `max-w-[160px]` → `max-w-[200px]`).  

### Testing
- Ran the frontend build and automated checks with `yarn build`, `yarn test`, and `yarn lint`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61e7ad99c83318d278c4f3895bcd1)