### PR TITLE
Add "Récapitulatif" view for supervisors and update surveillance schedule data

### DIFF
--- a/src/features/bac-dnb-surveillance/data/scheduleData.ts
+++ b/src/features/bac-dnb-surveillance/data/scheduleData.ts
@@ -83,7 +83,7 @@ export const scheduleData: ScheduleData = {
           ["Mme PORTER", "M. FALL B."],
           ["M. GOMIS", "M. FRAYON"],
           ["Mme MICHON GUI...", "Mme DUFAY"],
-          ["Mme GIBUS", "Mme MOURAIN DIOP"],
+          ["Mme GIBUS", "Mme PORTER"],
         ],
       },
       {
@@ -102,8 +102,8 @@ export const scheduleData: ScheduleData = {
           ["Mme GIBUS", "M. DIANDY"],
           ["Mme D'AQUINO", "M. FAYE"],
           ["Mme D'AQUINO", "Mme DRAME"],
-          ["M. BARITOU", "Mme MOURAIN DIOP"],
-          ["M. BARITOU", "Mme PEREZ"],
+          ["M. PIAGGIO", "Mme PORTER"],
+          ["M. PIAGGIO", "Mme PEREZ"],
         ],
       },
       {
@@ -162,11 +162,11 @@ export const scheduleData: ScheduleData = {
       { room: "SALLE 7", note: "(1/3 temps)", shifts: [["Mme JAÏT"], ["M. DIANDY"], ["M. NDIAYE"]] },
       {
         room: "SALLE 6",
-        shifts: [["M. FRAYON", "M. GOMIS"], ["M. FRAYON", "Mme DUFAY"], ["M. FRAYON"]],
+        shifts: [["M. FRAYON", "M. GOMIS"], ["M. FRAYON", "Mme DUFAY"], ["M. FRAYON", "Mme CHABERT"]],
       },
       {
         room: "SALLE 5",
-        shifts: [["Mme PORTER", "Mme CAPEL"], ["Mme PORTER"], ["Mme PORTER", "Mme FALL"]],
+        shifts: [["Mme PORTER", "Mme CAPEL"], ["Mme PORTER", "Mme BOSSU"], ["Mme PORTER", "Mme BOSSU"]],
       },
       {
         room: "SALLE 4",
@@ -174,11 +174,11 @@ export const scheduleData: ScheduleData = {
       },
       {
         room: "SALLE 3",
-        shifts: [["Mme BOSSU", "M. BARITOU"], ["M. FAYE", "M. SERVATE"], ["Mme MICHON GUI...", "Mme MOURAIN DIOP"]],
+        shifts: [["Mme BOSSU", "M. NDIAYE"], ["M. FAYE", "M. SERVATE"], ["Mme MICHON GUI...", "M. PIAGGIO"]],
       },
       {
         room: "SALLE 2",
-        shifts: [["Mme DRAME"], ["Mme DRAME", "M. NDOYE"], ["Mme DRAME", "Mme PEREZ"]],
+        shifts: [["Mme DRAME", "Mme CHABERT"], ["Mme DRAME", "M. NDOYE"], ["Mme DRAME", "Mme PEREZ"]],
       },
       { room: "SALLE 1", shifts: [["Mme DIADIO"], ["M. PIAGGIO"], ["M. DAVID"]] },
       { room: "Couloir et soutien", shifts: [["M. FALL B."], ["M. THOMAS"], []] },

--- a/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
+++ b/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
@@ -26,7 +26,7 @@ const HTML2CANVAS_OPTIONS = {
 import type { ExamColumn } from "../data/scheduleData";
 import { scheduleData } from "../data/scheduleData";
 
-type ExamType = "bac" | "dnb";
+type ExamType = "bac" | "dnb" | "recap";
 interface ShiftAssignment {
   room: string;
   col: ExamColumn;
@@ -225,7 +225,9 @@ export default function BacDnbSurveillancePage() {
   const selectedDnbShifts = selectedSupervisor ? supervisorShiftMap[selectedSupervisor]?.dnbShifts ?? [] : [];
   const totalSelectedShifts = selectedBacShifts.length + selectedDnbShifts.length;
   const normalizedSearch = searchTerm.trim().toLowerCase();
-  const allCards = scheduleData[currentExam].rows.flatMap((row) => row.shifts.flatMap((shift) => shift));
+  const allCards = (["bac", "dnb"] as const).flatMap((exam) =>
+    scheduleData[exam].rows.flatMap((row) => row.shifts.flatMap((shift) => shift)),
+  );
   const searchMatches = normalizedSearch
     ? allCards.filter((name) => name.toLowerCase().includes(normalizedSearch)).length
     : allCards.length;
@@ -256,7 +258,7 @@ export default function BacDnbSurveillancePage() {
   };
 
   const printMainPlanning = () => {
-    const title = currentExam === "bac" ? "Baccalauréat" : "DNB";
+    const title = currentExam === "bac" ? "Baccalauréat" : currentExam === "dnb" ? "DNB" : "Récapitulatif";
     const planningNode = document.getElementById("surveillance-planning-table");
     if (!planningNode) return;
 
@@ -426,74 +428,153 @@ export default function BacDnbSurveillancePage() {
           >
             DNB
           </button>
+          <button
+            onClick={() => setCurrentExam("recap")}
+            className={`rounded-md px-6 py-2.5 text-sm transition-all ${
+              currentExam === "recap"
+                ? "bg-white font-semibold text-indigo-700 shadow shadow-gray-200"
+                : "font-medium text-gray-600 hover:bg-gray-200/50 hover:text-gray-900"
+            }`}
+          >
+            Récapitulatif
+          </button>
         </div>
 
-        <div id="surveillance-planning-table" className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-md">
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[1000px] border-collapse text-left text-sm">
-              <thead className="border-b border-gray-200 bg-gray-50 text-gray-700">
-                <tr>
-                  <th className="sticky left-0 z-10 w-44 border-r border-gray-200 bg-white p-4" />
-                  {scheduleData[currentExam].columns.map((col) => (
-                    <th key={`${col.date}-${col.subject}`} className="min-w-[180px] border-r border-gray-100 p-4 align-top last:border-0">
-                      <div className="flex flex-col items-center space-y-2 text-center">
-                        <span className="text-xs font-semibold text-gray-500">{col.date}</span>
-                        <span
-                          className={`inline-flex items-center rounded-md px-2 py-1 text-sm font-bold ring-1 ring-inset ${col.bg} ${col.color} ${col.ring}`}
-                        >
-                          {col.subject}
-                        </span>
-                        <div className="mt-1 flex flex-col text-xs font-medium text-gray-600">
-                          <span>{col.time}</span>
-                          {col.endExtra ? <span className="text-gray-400">({col.endExtra})</span> : null}
-                        </div>
-                      </div>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200">
-                {scheduleData[currentExam].rows.map((row) => (
-                  <tr key={row.room} className="group transition-colors hover:bg-gray-50/50">
-                    <td className="sticky left-0 z-10 border-r border-gray-200 bg-white p-4 align-middle transition-colors group-hover:bg-gray-50/80">
-                      <div className="flex flex-col">
-                        <span className="font-bold text-gray-900">{row.room}</span>
-                        {row.note ? <span className="text-xs font-medium text-gray-500">{row.note}</span> : null}
-                      </div>
-                    </td>
-                    {row.shifts.map((shift, shiftIndex) => (
-                      <td key={`${row.room}-${shiftIndex}`} className="align-top border-r border-gray-100 p-3 last:border-0">
-                        <div className="flex flex-col gap-1.5">
-                          {shift.map((person) => {
-                            const isMatch =
-                              !normalizedSearch || person.toLowerCase().includes(normalizedSearch);
+        {currentExam === "recap" ? (
+          <div id="surveillance-planning-table" className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {supervisors
+              .filter((supervisor) => !normalizedSearch || supervisor.toLowerCase().includes(normalizedSearch))
+              .map((supervisor) => {
+                const shifts = supervisorShiftMap[supervisor];
+                if (!shifts) return null;
 
-                            return (
-                              <button
-                                key={`${row.room}-${person}-${shiftIndex}`}
-                                onClick={() => openConvocationMenu(person)}
-                                className={`flex w-full cursor-pointer items-center gap-2 rounded border p-2 text-left text-gray-700 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
-                                  isMatch
-                                    ? normalizedSearch
-                                      ? "scale-105 border-yellow-400 bg-yellow-100 ring-2 ring-yellow-400"
-                                      : "border-gray-200 bg-white hover:border-indigo-300 hover:ring-1 hover:ring-indigo-200"
-                                    : "border-gray-200 bg-white opacity-20 grayscale"
-                                }`}
-                              >
-                                <User className="h-3.5 w-3.5 flex-shrink-0 text-gray-400" />
-                                <span className="truncate text-xs font-medium">{person}</span>
-                              </button>
-                            );
-                          })}
+                const totalShifts = shifts.bacShifts.length + shifts.dnbShifts.length;
+
+                return (
+                  <article key={supervisor} className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+                    <div className="mb-5 flex items-center justify-between border-b border-gray-100 pb-5">
+                      <h3 className="text-2xl font-bold tracking-tight text-slate-900">{supervisor}</h3>
+                      <span className="rounded-full bg-indigo-100 px-3 py-1 text-sm font-bold text-indigo-700">
+                        {totalShifts} créneau(x)
+                      </span>
+                    </div>
+
+                    <div className="space-y-5">
+                      {shifts.bacShifts.length > 0 ? (
+                        <section>
+                          <h4 className="mb-2 text-xs font-bold uppercase tracking-wide text-slate-500">Baccalauréat</h4>
+                          <div className="space-y-1.5">
+                            {shifts.bacShifts.map((shift) => (
+                              <div key={`bac-${supervisor}-${shift.col.date}-${shift.col.subject}-${shift.room}`} className="grid grid-cols-[1fr_auto] items-center gap-2 text-sm text-slate-600">
+                                <span>
+                                  {shift.col.date} &nbsp;·&nbsp; {shift.col.time}
+                                </span>
+                                <span className="rounded-md bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+                                  {shift.room}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        </section>
+                      ) : null}
+
+                      {shifts.dnbShifts.length > 0 ? (
+                        <section>
+                          <h4 className="mb-2 text-xs font-bold uppercase tracking-wide text-slate-500">DNB</h4>
+                          <div className="space-y-1.5">
+                            {shifts.dnbShifts.map((shift) => (
+                              <div key={`dnb-${supervisor}-${shift.col.date}-${shift.col.subject}-${shift.room}`} className="grid grid-cols-[1fr_auto] items-center gap-2 text-sm text-slate-600">
+                                <span>
+                                  {shift.col.date} &nbsp;·&nbsp; {shift.col.time}
+                                </span>
+                                <span className="rounded-md bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+                                  {shift.room}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        </section>
+                      ) : null}
+                    </div>
+
+                    <button
+                      onClick={() => openConvocationMenu(supervisor)}
+                      className="mt-6 w-full rounded-xl bg-indigo-100 px-4 py-2.5 font-medium text-indigo-700 transition hover:bg-indigo-200"
+                    >
+                      Voir convocation
+                    </button>
+                  </article>
+                );
+              })}
+          </div>
+        ) : (
+          <div id="surveillance-planning-table" className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-md">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1000px] border-collapse text-left text-sm">
+                <thead className="border-b border-gray-200 bg-gray-50 text-gray-700">
+                  <tr>
+                    <th className="sticky left-0 z-10 w-44 border-r border-gray-200 bg-white p-4" />
+                    {scheduleData[currentExam].columns.map((col) => (
+                      <th key={`${col.date}-${col.subject}`} className="min-w-[180px] border-r border-gray-100 p-4 align-top last:border-0">
+                        <div className="flex flex-col items-center space-y-2 text-center">
+                          <span className="text-xs font-semibold text-gray-500">{col.date}</span>
+                          <span
+                            className={`inline-flex items-center rounded-md px-2 py-1 text-sm font-bold ring-1 ring-inset ${col.bg} ${col.color} ${col.ring}`}
+                          >
+                            {col.subject}
+                          </span>
+                          <div className="mt-1 flex flex-col text-xs font-medium text-gray-600">
+                            <span>{col.time}</span>
+                            {col.endExtra ? <span className="text-gray-400">({col.endExtra})</span> : null}
+                          </div>
                         </div>
-                      </td>
+                      </th>
                     ))}
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {scheduleData[currentExam].rows.map((row) => (
+                    <tr key={row.room} className="group transition-colors hover:bg-gray-50/50">
+                      <td className="sticky left-0 z-10 border-r border-gray-200 bg-white p-4 align-middle transition-colors group-hover:bg-gray-50/80">
+                        <div className="flex flex-col">
+                          <span className="font-bold text-gray-900">{row.room}</span>
+                          {row.note ? <span className="text-xs font-medium text-gray-500">{row.note}</span> : null}
+                        </div>
+                      </td>
+                      {row.shifts.map((shift, shiftIndex) => (
+                        <td key={`${row.room}-${shiftIndex}`} className="align-top border-r border-gray-100 p-3 last:border-0">
+                          <div className="flex flex-col gap-1.5">
+                            {shift.map((person) => {
+                              const isMatch =
+                                !normalizedSearch || person.toLowerCase().includes(normalizedSearch);
+
+                              return (
+                                <button
+                                  key={`${row.room}-${person}-${shiftIndex}`}
+                                  onClick={() => openConvocationMenu(person)}
+                                  className={`flex w-full cursor-pointer items-center gap-2 rounded border p-2 text-left text-gray-700 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                                    isMatch
+                                      ? normalizedSearch
+                                        ? "scale-105 border-yellow-400 bg-yellow-100 ring-2 ring-yellow-400"
+                                        : "border-gray-200 bg-white hover:border-indigo-300 hover:ring-1 hover:ring-indigo-200"
+                                      : "border-gray-200 bg-white opacity-20 grayscale"
+                                  }`}
+                                >
+                                  <User className="h-3.5 w-3.5 flex-shrink-0 text-gray-400" />
+                                  <span className="truncate text-xs font-medium">{person}</span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
+        )}
 
         {normalizedSearch && searchMatches === 0 ? (
           <div className="py-12 text-center text-gray-500">


### PR DESCRIPTION
### Motivation
- Provide a consolidated "Récapitulatif" view that shows each supervisor's Baccalauréat and DNB shifts in a compact card layout for easier overview and convocation access.
- Fix and update several personnel assignments in the surveillance schedule to reflect the latest room/shifts allocations.
- Ensure searching and printing behavior accounts for both exams when relevant.

### Description
- Added a new exam type `recap` to `ExamType` and a new tab button to toggle the recap view in `BacDnbSurveillancePage.tsx`.
- Implemented a supervisor-centric grid (`recap` mode) that displays per-supervisor cards listing their `bacShifts` and `dnbShifts` with a quick "Voir convocation" action, and wired the convocation modal to open from these cards.
- Changed `allCards` collection to aggregate names from both `bac` and `dnb` for consistent searching across exams and updated `printMainPlanning` to use `Récapitulatif` when `currentExam` is `recap`.
- Updated schedule data in `src/features/bac-dnb-surveillance/data/scheduleData.ts` with multiple assignment changes (examples: SALLE 7 and SALLE 5 adjustments for the bac schedule; several DNB staff replacements such as adding `Mme CHABERT` and `Mme BOSSU` in relevant shifts).

### Testing
- Ran TypeScript type-check and local build (`yarn build`/`tsc`) to validate typings and compilation, which completed successfully.
- Ran the project test suite (`yarn test`), and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e795eb667c83319b8ecabaece51273)