### PR TITLE
Add SALLE 2 Charlie Rispale to BAC/DNB surveillance schedule

### DIFF
--- a/src/features/bac-dnb-surveillance/data/scheduleData.ts
+++ b/src/features/bac-dnb-surveillance/data/scheduleData.ts
@@ -126,6 +126,10 @@ export const scheduleData: ScheduleData = {
           ["Mme MICHON GUI...", "Mme JAÏT"],
         ],
       },
+      {
+        room: "SALLE 2 Charlie Rispale",
+        shifts: [["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"]],
+      },
     ],
   },
   dnb: {


### PR DESCRIPTION
### Motivation
- Add a missing room to the BAC/DNB supervision schedule so the `Vie scolaire` assignment for SALLE 2 is represented in the data.

### Description
- Inserted a new room entry in `src/features/bac-dnb-surveillance/data/scheduleData.ts` named `"SALLE 2 Charlie Rispale"` with five shifts set to `["Vie scolaire"]`.

### Testing
- Ran a TypeScript type check with `tsc --noEmit` and the existing test suite via `yarn test`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a1acec7883319e920c713c586a84)