### PR TITLE
Vider les deux premiers créneaux pour SALLE 2 Charlie Rispale

### DIFF
--- a/src/features/bac-dnb-surveillance/data/scheduleData.ts
+++ b/src/features/bac-dnb-surveillance/data/scheduleData.ts
@@ -128,7 +128,7 @@ export const scheduleData: ScheduleData = {
       },
       {
         room: "SALLE 2 Charlie Rispale",
-        shifts: [["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"]],
+        shifts: [[], [], ["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"]],
       },
     ],
   },


### PR DESCRIPTION
### Motivation
- Mettre à jour le planning BAC pour la ligne `SALLE 2 Charlie Rispale` afin de supprimer les surveillances des deux premiers créneaux et refléter l'absence d'épreuve pour l'élève.

### Description
- Dans `src/features/bac-dnb-surveillance/data/scheduleData.ts` la propriété `shifts` de la ligne `SALLE 2 Charlie Rispale` est passée de `["Vie scolaire", "Vie scolaire", "Vie scolaire", "Vie scolaire", "Vie scolaire"]` à `[[], [], ["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"]]`.

### Testing
- Tentative de build avec `npm run build` : échec (environnement: `vite` introuvable). 
- Tentative d'installation des dépendances avec `npm install` : échec (conflit de dépendances npm `ERESOLVE`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b0ca1b408331bdf4840edb40587e)