### PR TITLE
Separate SALLE 2 label and style Charlie Rispal note

### DIFF
--- a/src/features/bac-dnb-surveillance/data/scheduleData.ts
+++ b/src/features/bac-dnb-surveillance/data/scheduleData.ts
@@ -127,7 +127,8 @@ export const scheduleData: ScheduleData = {
         ],
       },
       {
-        room: "SALLE 2 Charlie Rispale",
+        room: "SALLE 2",
+        note: "Charlie Rispal",
         shifts: [[], [], ["Vie scolaire"], ["Vie scolaire"], ["Vie scolaire"]],
       },
     ],

--- a/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
+++ b/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
@@ -538,7 +538,15 @@ export default function BacDnbSurveillancePage() {
                       <td className="sticky left-0 z-10 border-r border-gray-200 bg-white p-4 align-middle transition-colors group-hover:bg-gray-50/80">
                         <div className="flex flex-col">
                           <span className="font-bold text-gray-900">{row.room}</span>
-                          {row.note ? <span className="text-xs font-medium text-gray-500">{row.note}</span> : null}
+                          {row.note ? (
+                            <span
+                              className={`text-xs text-gray-500 ${
+                                row.note === "Charlie Rispal" ? "font-normal italic" : "font-medium"
+                              }`}
+                            >
+                              {row.note}
+                            </span>
+                          ) : null}
                         </div>
                       </td>
                       {row.shifts.map((shift, shiftIndex) => (


### PR DESCRIPTION
### Motivation
- Afficher un saut de ligne entre la salle et la personne assignée en mettant le nom sur la ligne en-dessous de la salle. 
- Faire apparaître « Charlie Rispal » en italique et non en gras tout en conservant la même taille que les autres notes.

### Description
- Modifié `src/features/bac-dnb-surveillance/data/scheduleData.ts` pour remplacer `room: "SALLE 2 Charlie Rispale"` par `room: "SALLE 2"` et ajouter `note: "Charlie Rispal"` (correction orthographique). 
- Mis à jour le rendu dans `src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx` pour afficher `row.note` en `text-xs text-gray-500` et appliquer `font-normal italic` uniquement quand la note vaut `"Charlie Rispal"`, sinon conserver `font-medium` pour les autres notes.
- Aucun changement de logique des créneaux (`shifts`) n’a été effectué.

### Testing
- `npm ci` a échoué à cause d’un conflit de peer-dependencies (`eslint` / `@typescript-eslint`) dans cet environnement (échec attendu ici). 
- `npm install --legacy-peer-deps` a réussi. 
- `npm run build` (qui exécute `tsc --noEmit && vite build`) a réussi et a produit un build de production sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b4608eb48331bdb7d42b88b5d7ca)