### PR TITLE
Organiser le tableau des jurés par juré

### DIFF
--- a/src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx
+++ b/src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx
@@ -79,7 +79,7 @@ const ROWS: string[][] = [
 
 
 
-const JURY_COLUMNS = ["Heure", "Candidat", "Problématique", "Discipline_1", "Discipline_2", "Langue"] as const;
+const JURY_COLUMNS = ["Juré", "Heure", "Candidat", "Problématique", "Discipline_1", "Discipline_2", "Langue"] as const;
 
 type TabKey = "candidats" | "jures";
 
@@ -87,7 +87,18 @@ export default function DnbOralExam20260520Page() {
   const [activeTab, setActiveTab] = useState<TabKey>("candidats");
 
   const juryRows = useMemo(() =>
-    ROWS.filter((row) => row[10] || row[11]).map((row) => [row[12], row[0], row[3], row[4], row[5], row[8] === "TRUE" ? "Anglais" : row[9] === "TRUE" ? "Espagnol" : ""]),
+    ROWS.flatMap((row) => {
+      const jurors = [row[10], row[11]].filter(Boolean);
+      const language = row[8] === "TRUE" ? "Anglais" : row[9] === "TRUE" ? "Espagnol" : "";
+
+      return jurors.map((juror) => [juror, row[12], row[0], row[3], row[4], row[5], language]);
+    }).sort((a, b) => {
+      if (a[0] !== b[0]) {
+        return a[0].localeCompare(b[0], "fr");
+      }
+
+      return a[1].localeCompare(b[1], "fr");
+    }),
   []);
 
   return (


### PR DESCRIPTION
### Motivation
- Rendre l’onglet `Jurés` lisible par juré afin que chaque juré apparaisse avec ses convocations, ses problématiques et ses candidats.  
- Faciliter l’impression/export et la gestion opérationnelle en ayant une ligne par juré plutôt qu’une ligne par candidat regroupant plusieurs jurés.  

### Description
- Ajoute la colonne `Juré` au tableau des jurés en modifiant `JURY_COLUMNS` dans `src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx`.  
- Remplace la construction précédente de `juryRows` par un `flatMap` qui génère une entrée distincte pour chaque juré (`Juré_1` et `Juré_2`) et inclut la langue détectée (`Anglais`/`Espagnol`) dans chaque ligne.  
- Trie les lignes de planning par nom de juré puis par `Heure de convocation` pour un affichage ordonné (`localeCompare` avec `fr`).  

### Testing
- `npm run build` a été exécuté et a échoué avec l’erreur `sh: 1: vite: not found`.  
- `npm ci` a été exécuté et a échoué en raison d’un conflit de peer dependencies entre `eslint@9` et `@typescript-eslint/eslint-plugin@7`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1bf4350883318bdc70f64ca189bd)