### PR TITLE
DNB: remove "Confirmé PP"/"Groupe" from candidats and show language booleans as checkboxes

### DIFF
--- a/src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx
+++ b/src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx
@@ -1,15 +1,13 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 
-const COLUMNS = [
+const CANDIDATE_COLUMNS = [
   "Élève",
   "Classe",
   "Parcours",
   "Problématique",
   "Discipline_1",
   "Discipline_2",
-  "Confirmé PP",
-  "Groupe",
   "Anglais",
   "Espagnol",
   "Juré_1",
@@ -86,6 +84,20 @@ type TabKey = "candidats" | "jures";
 export default function DnbOralExam20260520Page() {
   const [activeTab, setActiveTab] = useState<TabKey>("candidats");
 
+
+  const candidateRows = useMemo(() =>
+    ROWS.map((row) => {
+      const displayRow = row.filter((_, index) => index !== 6 && index !== 7);
+      return displayRow.map((cell, index) => {
+        const isLanguageColumn = index === 6 || index === 7;
+        if (!isLanguageColumn) {
+          return cell;
+        }
+
+        return cell === "TRUE" ? "☑" : "";
+      });
+    }),
+  []);
   const juryRows = useMemo(() =>
     ROWS.flatMap((row) => {
       const jurors = [row[10], row[11]].filter(Boolean);
@@ -127,13 +139,13 @@ export default function DnbOralExam20260520Page() {
           <table className="min-w-full text-left text-sm">
             <thead className="bg-slate-100 text-slate-700">
               <tr>
-                {(activeTab === "candidats" ? COLUMNS : JURY_COLUMNS).map((column) => (
+                {(activeTab === "candidats" ? CANDIDATE_COLUMNS : JURY_COLUMNS).map((column) => (
                   <th key={column} className="whitespace-nowrap border-b px-3 py-2 font-semibold">{column}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
-              {(activeTab === "candidats" ? ROWS : juryRows).map((row, index) => (
+              {(activeTab === "candidats" ? candidateRows : juryRows).map((row, index) => (
                 <tr key={`${row[0]}-${index}`} className="odd:bg-white even:bg-slate-50">
                   {row.map((cell, cellIndex) => (
                     <td key={`${index}-${cellIndex}`} className="align-top border-b px-3 py-2">{cell}</td>


### PR DESCRIPTION
### Motivation
- Simplifier l'affichage du tableau des Candidats en retirant les colonnes inutiles `Confirmé PP` et `Groupe` tout en conservant les données sources pour l'onglet Jurés.
- Rendre plus lisible la colonne langue en remplaçant `TRUE`/`FALSE` par des cases cochées pour `TRUE` et vides pour `FALSE`.

### Description
- Renommé la constante `COLUMNS` en `CANDIDATE_COLUMNS` et supprimé les entrées `"Confirmé PP"` et `"Groupe"` des en-têtes affichés dans `src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx`.
- Ajouté un `useMemo` dérivé `candidateRows` qui filtre les colonnes 6 et 7 (les deux colonnes supprimées) pour l'affichage des candidats tout en préservant le tableau source `ROWS` pour l'onglet `jures`.
- Transformé les valeurs `TRUE`/`FALSE` des colonnes `Anglais` et `Espagnol` en rendu `"☑"` pour `TRUE` et `""` pour `FALSE` lors de la construction de `candidateRows`.
- Mis à jour le rendu du tableau pour utiliser `CANDIDATE_COLUMNS`/`candidateRows` pour l'onglet `candidats` et laisser `JURY_COLUMNS`/`juryRows` inchangés pour l'onglet `jures`.

### Testing
- Exécuté `npm run build`; TypeScript s'est lancé mais la commande a échoué en phase de bundling à cause d'un outil manquant (`vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1c7eec3c8331a111d580a3a8439d)