### PR TITLE
Apply tricolor icon only to 'Oraux du DNB' home card

### DIFF
--- a/src/features/home/pages/HomePage.tsx
+++ b/src/features/home/pages/HomePage.tsx
@@ -26,12 +26,8 @@ export default function HomePage() {
     surveillance: FileCheck2,
   };
 
-  const iconBackgroundByCategory: Record<HomeCalloutEntry["category"], string> = {
-    general: "bg-gradient-to-br from-sky-500 to-indigo-500",
-    math: "bg-gradient-to-br from-sky-500 to-indigo-500",
-    oral: "bg-gradient-to-r from-blue-600 via-white to-red-600 text-slate-900",
-    surveillance: "bg-gradient-to-r from-blue-600 via-white to-red-600 text-slate-900",
-  };
+  const defaultIconBackground = "bg-gradient-to-br from-sky-500 to-indigo-500";
+  const oralDnbIconBackground = "bg-gradient-to-r from-blue-600 via-white to-red-600 text-slate-900";
 
   return (
     <HomeLayout>
@@ -55,7 +51,11 @@ export default function HomePage() {
               title={entry.title}
               footerLabel={entry.footerLabel}
               meta={<HomeEventMeta icon={CalendarDays} label={entry.dateLabel} description="" />}
-              iconBackgroundClassName={iconBackgroundByCategory[entry.category]}
+              iconBackgroundClassName={
+                entry.to === "/examens-blancs/oraux-dnb-2026-05-20"
+                  ? oralDnbIconBackground
+                  : defaultIconBackground
+              }
             />
           );
         })}


### PR DESCRIPTION
### Motivation
- Ensure that only the "Oraux du DNB" home card uses the blue/white/red tricolor icon background while all other cards keep the default blue gradient.

### Description
- In `src/features/home/pages/HomePage.tsx` replaced the per-category background map with a `defaultIconBackground` and an `oralDnbIconBackground` and set `iconBackgroundClassName` to use the tricolor only when `entry.to === "/examens-blancs/oraux-dnb-2026-05-20"`.

### Testing
- Ran the build command `npm run build`, which could not complete in this environment because `vite` is not installed (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff021730dc83319f5ae0c8404dfd65)