### PR TITLE
Make BAC/DNB surveillance card icon tricolor

### DIFF
--- a/src/features/home/pages/HomePage.tsx
+++ b/src/features/home/pages/HomePage.tsx
@@ -52,7 +52,8 @@ export default function HomePage() {
               footerLabel={entry.footerLabel}
               meta={<HomeEventMeta icon={CalendarDays} label={entry.dateLabel} description="" />}
               iconBackgroundClassName={
-                entry.to === "/examens-blancs/oraux-dnb-2026-05-20"
+                entry.to === "/examens-blancs/oraux-dnb-2026-05-20" ||
+                entry.to === "/surveillances-bac-dnb"
                   ? oralDnbIconBackground
                   : defaultIconBackground
               }


### PR DESCRIPTION
### Motivation
- Ensure the "Surveillances BAC et DNB" home card uses the same blue-white-red (tricolor) icon background as the DNB oral card so it visually matches the exam-related styling.

### Description
- Updated `src/features/home/pages/HomePage.tsx` to extend the `iconBackgroundClassName` condition so that `entry.to === "/surveillances-bac-dnb"` also uses the `oralDnbIconBackground` gradient used for the DNB oral card.
- Preserved the existing default gradient for all other cards by falling back to `defaultIconBackground` when the route does not match the targeted paths.

### Testing
- Ran `npm run -s lint` and it failed due to the repository lacking an `eslint.config.*` flat config required by the installed ESLint version, which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff03158c4083318f5c0c8a6b6f1307)