### PR TITLE
Embed production DNB oral page via full‑screen iframe

### DIFF
--- a/src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx
+++ b/src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx
@@ -1,7 +1,13 @@
 export default function DnbOralExam20260520Page() {
   return (
-    <main className="mx-auto max-w-4xl px-6 py-16 text-center">
-      <h1 className="text-2xl font-bold text-slate-900">Page en construction</h1>
+    <main className="h-[calc(100vh-4rem)] w-full bg-slate-50">
+      <iframe
+        title="Oraux DNB 2026-05-20"
+        src="https://examensblancslfjp.netlify.app/examens-blancs/oraux-dnb-2026-05-20"
+        className="h-full w-full border-0"
+        loading="lazy"
+        referrerPolicy="no-referrer"
+      />
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide the requested DNB oral page content by loading the production view at the Netlify URL instead of leaving a placeholder "page en construction" component.

### Description
- Replace the placeholder rendering in `src/features/dnb-oral-202605/pages/DnbOralExam20260520Page.tsx` with a full‑height `iframe` that loads `https://examensblancslfjp.netlify.app/examens-blancs/oraux-dnb-2026-05-20`.
- Keep the integration minimal and route compatible by only changing the page component to embed the external production page.

### Testing
- Ran `npm run build` to validate the change, and the build failed in this environment because `vite` is not available (`sh: 1: vite: not found`).
- Sanity-checked the updated component file content locally to ensure the `iframe` attributes (`title`, `src`, `className`, `loading`, `referrerPolicy`) are present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff065ecb1083319160167da928e17a)