### PR TITLE
Add index redirect to OralDNB2026 website

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,36 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
-    <script type="text/javascript">
-      (function (l) {
-        if (l.search[1] === "/") {
-          var decoded = l.search
-            .slice(1)
-            .split("&")
-            .map(function (s) {
-              return s.replace(/~and~/g, "&");
-            })
-            .join("?");
-
-          window.history.replaceState(
-            null,
-            "",
-            l.pathname.slice(0, -1) + decoded + l.hash,
-          );
-        }
-      })(window.location);
+    <meta http-equiv="refresh" content="0; url=https://bastiencapel.github.io/OralDNB2026/" />
+    <title>Redirection vers Oral DNB 2026</title>
+    <script>
+      window.location.replace('https://bastiencapel.github.io/OralDNB2026/');
     </script>
-    <title>examen.blanc.LFJP</title>
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <p>
+      Redirection en cours…
+      <a href="https://bastiencapel.github.io/OralDNB2026/">Cliquer ici si la page ne s'ouvre pas automatiquement</a>.
+    </p>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a simple landing page at `index.html` that immediately redirects to `https://bastiencapel.github.io/OralDNB2026/`.
- Avoid bootstrapping the local SPA when the intent is to open the published site instead.
- Ensure the redirect works in a variety of environments by including multiple redirect mechanisms and a fallback link.

### Description
- Replace the previous app bootstrap content in `index.html` with a minimal redirect page.
- Add a `meta` refresh (`meta http-equiv="refresh"`) and a `window.location.replace(...)` script targeting the Oral DNB 2026 site.
- Remove font links, favicon and the module script reference to the local app, and add a fallback clickable link and an updated `<title>`.

### Testing
- No automated tests were run because this is a static HTML redirect change only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff09817f58833198b9552a59a5170c)