### PR TITLE
Gérer les liens externes pour la tuile « Oraux du DNB »

### DIFF
--- a/src/features/home/components/HomeCallToActionCard.tsx
+++ b/src/features/home/components/HomeCallToActionCard.tsx
@@ -23,12 +23,10 @@ export default function HomeCallToActionCard({
   meta,
   iconBackgroundClassName = "bg-gradient-to-br from-sky-500 to-indigo-500",
 }: HomeCallToActionCardProps) {
-  return (
-    <Link
-      to={to}
-      className="group relative w-full overflow-hidden rounded-3xl border border-slate-200 bg-white p-8 text-left shadow-lg transition-transform duration-300 hover:scale-[1.02] hover:shadow-xl sm:p-10"
-      aria-label={iconLabel}
-    >
+  const isExternal = to.startsWith("http://") || to.startsWith("https://");
+
+  const cardContent = (
+    <>
       <div className="absolute -left-24 -top-24 h-48 w-48 rounded-full bg-sky-200/60 blur-3xl transition-opacity duration-300 group-hover:opacity-60" />
       <div className="absolute -bottom-16 -right-16 h-56 w-56 rounded-full bg-indigo-200/70 blur-3xl transition-opacity duration-300 group-hover:opacity-60" />
 
@@ -54,6 +52,23 @@ export default function HomeCallToActionCard({
           →
         </span>
       </div>
+    </>
+  );
+
+  const className =
+    "group relative w-full overflow-hidden rounded-3xl border border-slate-200 bg-white p-8 text-left shadow-lg transition-transform duration-300 hover:scale-[1.02] hover:shadow-xl sm:p-10";
+
+  if (isExternal) {
+    return (
+      <a href={to} className={className} aria-label={iconLabel}>
+        {cardContent}
+      </a>
+    );
+  }
+
+  return (
+    <Link to={to} className={className} aria-label={iconLabel}>
+      {cardContent}
     </Link>
   );
 }

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -114,7 +114,7 @@ export const HOME_DNB_ZAO_202602_ENTRY: HomeCalloutEntry = {
 };
 
 export const HOME_DNB_ORAL_20260520_ENTRY: HomeCalloutEntry = {
-  to: "/examens-blancs/oraux-dnb-2026-05-20",
+  to: "https://bastiencapel.github.io/OralDNB2026/",
   iconLabel: "Consulter l'organisation des oraux du DNB",
   subtitle: "",
   title: "Oraux du DNB",


### PR DESCRIPTION
### Motivation
- La tuile « Oraux du DNB » doit ouvrir un site externe plutôt qu’une route interne du SPA. 
- Le composant de tuile doit prendre en charge autant les routes internes que les URL externes sans modifier l’apparence ou l’accessibilité.

### Description
- Remplacement de la propriété `to` de l’entrée `HOME_DNB_ORAL_20260520_ENTRY` pour pointer vers `https://bastiencapel.github.io/OralDNB2026/` (fichier `src/features/home/constants.ts`).
- Refactor de `HomeCallToActionCard` (`src/features/home/components/HomeCallToActionCard.tsx`) pour détecter les URL externes (`to.startsWith('http://')` ou `'https://'`) et rendre un `<a href=...>` au lieu d’un `<Link>` tout en réutilisant le même contenu visuel et les mêmes classes.
- Extraction du contenu de la carte dans `cardContent` et du `className` partagé pour éviter la duplication et préserver `aria-label` et le rendu identique entre lien interne et externe.

### Testing
- Tentative de build avec `npm run build` effectuée dans l’environnement de déploiement et elle a échoué en raison de l’absence de l’outil `vite` (`vite: not found`).
- Les modifications ont été ajoutées et validées en local dans le dépôt (commit créé), aucune suite de tests automatisés additionnelle n’a été exécutée dans ce conteneur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0a99e8d88331a6accc4694c32045)