### PR TITLE
Permute oral exam times for WONE Oumar and SARR Mame Diarra Bousso

### DIFF
--- a/src/features/french-oral-exam-202605/data/candidates.ts
+++ b/src/features/french-oral-exam-202605/data/candidates.ts
@@ -61,11 +61,11 @@ export const oralCandidates202605: OralCandidate[] = [
 
   { candidate: "SARR Sokhna Faty", className: "1ERE1", date: "2026-05-13", convocationTime: "07:50", examTime: "08:30", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: true },
   { candidate: "LAURIENTE Alexandra", className: "1ERE1", date: "2026-05-13", convocationTime: "08:30", examTime: "09:00", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
-  { candidate: "SARR Mame Diarra Bousso", className: "1ERE2", date: "2026-05-13", convocationTime: "09:00", examTime: "09:30", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
+  { candidate: "SARR Mame Diarra Bousso", className: "1ERE2", date: "2026-05-13", convocationTime: "11:00", examTime: "11:30", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
   { candidate: "D'ALMEIDA Kyran", className: "1ERE2", date: "2026-05-13", convocationTime: "09:30", examTime: "10:00", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
   { candidate: "SECK Ousseynatou", className: "1ERE1", date: "2026-05-13", convocationTime: "10:00", examTime: "10:30", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
   { candidate: "TSHIBANDA Raymond", className: "1ERE1", date: "2026-05-13", convocationTime: "10:30", examTime: "11:00", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
-  { candidate: "WONE Oumar", className: "1ERE2", date: "2026-05-13", convocationTime: "11:00", examTime: "11:30", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
+  { candidate: "WONE Oumar", className: "1ERE2", date: "2026-05-13", convocationTime: "09:00", examTime: "09:30", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
   { candidate: "FALL Cheikh Saliou Mbacké", className: "1ERE1", date: "2026-05-13", convocationTime: "11:30", examTime: "12:00", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
   { candidate: "SAMBA Babacar", className: "1ERE2", date: "2026-05-13", convocationTime: "12:00", examTime: "12:30", jury: "Mme MOURAIN DIOP", room: "14", hasExtendedTime: false },
 ];


### PR DESCRIPTION
### Motivation
- Swap the scheduled convocation and exam times for two candidates on `2026-05-13` in the May 2026 French oral exam dataset to reflect the requested timetable change.

### Description
- In `src/features/french-oral-exam-202605/data/candidates.ts` the entries for `SARR Mame Diarra Bousso` and `WONE Oumar` were swapped so that `SARR Mame Diarra Bousso` is now `11:00 / 11:30` and `WONE Oumar` is now `09:00 / 09:30` (convocation / exam).

### Testing
- No automated tests were run because this is a data-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0334dab69c833191a7dd7dd32f1d87)