### PR TITLE
Décale le bac blanc de mathématiques du 23 au 22 mai

### DIFF
--- a/src/features/math-exam-dashboard/data/datasets/math-2026-05-22.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-05-22.ts
@@ -137,3 +137,7 @@ export const mathExamDashboardData20260522: MathExamDashboardData = {
   typeVariants: defaultTypeVariants,
   dashboardTabs: defaultDashboardTabs,
 };
+
+
+// Alias de compatibilité pour les imports existants de la page 2026-05-23
+export const mathExamDashboardData20260523 = mathExamDashboardData20260522;

--- a/src/features/math-exam-dashboard/data/datasets/math-2026-05-22.ts
+++ b/src/features/math-exam-dashboard/data/datasets/math-2026-05-22.ts
@@ -14,7 +14,7 @@ const teacherDirectory = createTeacherDirectory([
 
 const roomSchedule: RoomScheduleDay[] = [
   {
-    day: "Samedi 23/05",
+    day: "Vendredi 22/05",
     rooms: {
       S10: [
         {
@@ -56,10 +56,10 @@ const roomSchedule: RoomScheduleDay[] = [
   },
 ];
 
-export const mathExamDashboardData20260523: MathExamDashboardData = {
+export const mathExamDashboardData20260522: MathExamDashboardData = {
   header: {
     title: "Bac blanc de mathématiques 1ère",
-    date: "Samedi 23 mai 2026 • 11h10",
+    date: "Vendredi 22 mai 2026 • 11h10",
     reprographyDeadline: {
       label: "Mardi 19 mai 2026",
     },
@@ -94,7 +94,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
   surveillanceSchedule: [
     {
       teacher: "CAPEL E.",
-      datetime: "samedi 23/05 à 11h10",
+      datetime: "vendredi 22/05 à 11h10",
       room: "S15",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",
@@ -102,7 +102,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
     },
     {
       teacher: "FRAYON A.",
-      datetime: "samedi 23/05 à 11h10",
+      datetime: "vendredi 22/05 à 11h10",
       room: "S13",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",
@@ -110,7 +110,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
     },
     {
       teacher: "NDOYE A.",
-      datetime: "samedi 23/05 à 11h10",
+      datetime: "vendredi 22/05 à 11h10",
       room: "S14",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",
@@ -118,7 +118,7 @@ export const mathExamDashboardData20260523: MathExamDashboardData = {
     },
     {
       teacher: "SERVATE S.",
-      datetime: "samedi 23/05 à 11h10",
+      datetime: "vendredi 22/05 à 11h10",
       room: "S10",
       mission: "Bac blanc mathématiques 1ère",
       duration: "2:00:00",

--- a/src/features/math-exam-dashboard/data/index.ts
+++ b/src/features/math-exam-dashboard/data/index.ts
@@ -1,5 +1,5 @@
 export * from "./types";
 export * from "./datasets/math-2026-02-13";
-export * from "./datasets/math-2026-05-23";
+export * from "./datasets/math-2026-05-22";
 export * from "./datasets/eaf-2026-04-07";
 export * from "./datasets/dnb-zao-2026-02";


### PR DESCRIPTION
### Motivation
- Avancer d’un jour l’épreuve de mathématiques prévue initialement le samedi 23 mai pour refléter la nouvelle date et mettre à jour toutes les convocations des surveillants associées.

### Description
- Renommage du dataset `src/features/math-exam-dashboard/data/datasets/math-2026-05-23.ts` en `math-2026-05-22.ts` et adaptation du contenu du fichier pour la nouvelle date.  
- Mise à jour du champ `day` dans `roomSchedule` de `"Samedi 23/05"` à `"Vendredi 22/05"` et de l’en-tête `header.date` à `"Vendredi 22 mai 2026 • 11h10"`.  
- Modification de l’identifiant exporté de `mathExamDashboardData20260523` vers `mathExamDashboardData20260522` pour refléter la nouvelle date.  
- Mise à jour de toutes les entrées `datetime` de `surveillanceSchedule` de `"samedi 23/05 à 11h10"` à `"vendredi 22/05 à 11h10"` et ajustement de l’export central dans `src/features/math-exam-dashboard/data/index.ts` pour pointer vers le nouveau fichier.

### Testing
- Exécution de la construction avec `npm run build` (inclut `tsc --noEmit && vite build`) qui a échoué dans cet environnement en indiquant `vite: not found`, empêchant une build complète réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acb64ed7483318f8fd3b62035ab2a)