### PR TITLE
Trier les surveillants par nom de famille

### DIFF
--- a/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
+++ b/src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx
@@ -56,6 +56,13 @@ function getArrivalTime(timeStr: string) {
   return "30 min avant";
 }
 
+function getSupervisorSortKey(name: string) {
+  return name
+    .trim()
+    .replace(/^(?:M(?:me|lle)?\.?|Monsieur|Madame)\s+/i, "")
+    .toLocaleLowerCase("fr");
+}
+
 function getUniqueSupervisors() {
   const supervisors = new Set<string>();
   ["bac", "dnb"].forEach((exam) => {
@@ -68,7 +75,9 @@ function getUniqueSupervisors() {
     });
   });
 
-  return [...supervisors].sort();
+  return [...supervisors].sort((a, b) =>
+    getSupervisorSortKey(a).localeCompare(getSupervisorSortKey(b), "fr", { sensitivity: "base" }),
+  );
 }
 
 function buildSupervisorShifts(supervisor: string, exam: ExamType): ShiftAssignment[] {


### PR DESCRIPTION
### Motivation
- Le tri actuel liste les surveillants en se basant sur la chaîne affichée (incluant la civilité), ce qui donne un ordre non souhaité en français; il faut trier par nom de famille.

### Description
- Ajoute la fonction `getSupervisorSortKey(name: string)` qui enlève la civilité (`M.`, `Mme`, `Mlle`, `Monsieur`, `Madame`) et normalise la clé en minuscules via `toLocaleLowerCase("fr")`.
- Remplace l'appel à `sort()` brut par un tri utilisant `localeCompare` en `fr` sur la clé fournie par `getSupervisorSortKey` dans `getUniqueSupervisors`.
- Fichier modifié : `src/features/bac-dnb-surveillance/pages/BacDnbSurveillancePage.tsx`.

### Testing
- `npm run build` a été lancé et a échoué avec `vite: not found` dans l'environnement (échec).
- `npm install` a été lancé et a échoué à cause d'un conflit de dépendances npm entre `eslint@9` et `@typescript-eslint/eslint-plugin` qui attend une version d`'eslint` 8 (échec).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d62244710833188ac97d6abb7ef16)