### PR TITLE
Remplacer M. NDOYE par "Vie scolaire" dans le planning de surveillance (8–9 juin)

### DIFF
--- a/src/features/bac-dnb-surveillance/data/scheduleData.ts
+++ b/src/features/bac-dnb-surveillance/data/scheduleData.ts
@@ -89,7 +89,7 @@ export const scheduleData: ScheduleData = {
       {
         room: "SALLE 6",
         shifts: [
-          ["M. NDAW", "M. NDOYE"],
+          ["M. NDAW", "Vie scolaire"],
           ["Mme DRAME", "M. DIANDY"],
           ["Mme CAPEL", "M. PIAGGIO"],
           ["Mme MBOUP", "Mme CAPEL"],
@@ -121,7 +121,7 @@ export const scheduleData: ScheduleData = {
         shifts: [
           ["M. FAYE", "M. FRAYON"],
           ["Mme DIADIO", "M. NDAW"],
-          ["Mme DIADIO", "M. NDOYE"],
+          ["Mme DIADIO", "Vie scolaire"],
           ["M. DAVID", "Mme PEREZ"],
           ["Mme MICHON GUI...", "Mme JAÏT"],
         ],


### PR DESCRIPTION
### Motivation
- Mettre à jour la page de surveillance BAC de juin pour refléter que la surveillance des 8 et 9 juin est assurée par la "Vie scolaire" plutôt que par M. NDOYE.

### Description
- Fichier modifié : `src/features/bac-dnb-surveillance/data/scheduleData.ts`.
- Remplacement de `"M. NDOYE"` par `"Vie scolaire"` pour le créneau du 08/06/2026 en `SALLE 6`.
- Remplacement de `"M. NDOYE"` par `"Vie scolaire"` pour le créneau du 09/06/2026 en `SALLE 3`.
- Aucune autre logique ou composant n'a été modifié, uniquement les données du planning.

### Testing
- Recherche des occurrences avant/après avec `rg` pour s'assurer que les remplacements ciblent uniquement les entrées voulues (réussi).
- Remplacement automatisé effectué via un script Python local (réussi).
- Inspection du diff du fichier modifié pour vérification finale des changements appliqués (réussi).
- Aucun test unitaire automatique pertinent n'a été exécuté pour cette modification de données.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df01a08008331ae658eef0528787b)