### PR TITLE
Remplace Vie scolaire par Mme MBOUP

### DIFF
--- a/src/features/bac-dnb-surveillance/data/scheduleData.ts
+++ b/src/features/bac-dnb-surveillance/data/scheduleData.ts
@@ -89,7 +89,7 @@ export const scheduleData: ScheduleData = {
       {
         room: "SALLE 6",
         shifts: [
-          ["M. NDAW", "Vie scolaire"],
+          ["M. NDAW", "Mme MBOUP"],
           ["Mme DRAME", "M. DIANDY"],
           ["Mme CAPEL", "M. PIAGGIO"],
           ["Mme MBOUP", "Mme CAPEL"],


### PR DESCRIPTION
### Motivation
- Remplacer l'affectation générique « Vie scolaire » par la surveillante réelle afin que la convocation générée inclue Mme MBOUP pour la surveillance en SALLE 6 (premier créneau).

### Description
- Modification unique dans `src/features/bac-dnb-surveillance/data/scheduleData.ts` : remplacement de `["M. NDAW", "Vie scolaire"]` par `["M. NDAW", "Mme MBOUP"]` pour la salle `SALLE 6`.

### Testing
- Exécuté `npm ci --legacy-peer-deps && npm run build` (build réussi) et `git diff --check` (aucun problème détecté); `npm run lint` échoue à cause de l'absence de `eslint.config.js` (incompatibilité ESLint v9) et l'installation de `playwright-chromium` a échoué en raison d'un téléchargement Chromium bloqué (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186ff005e8833199103e0e4b5fd9c8)