### PR TITLE
Swap DNB maths room assignments

### DIFF
--- a/src/features/bac-dnb-surveillance/data/scheduleData.ts
+++ b/src/features/bac-dnb-surveillance/data/scheduleData.ts
@@ -164,7 +164,7 @@ export const scheduleData: ScheduleData = {
       },
     ],
     rows: [
-      { room: "SALLE 7", note: "(1/3 temps)", shifts: [["Mme JAÏT"], ["M. DIANDY"], ["M. NDIAYE"]] },
+      { room: "SALLE 7", note: "(1/3 temps)", shifts: [["Mme JAÏT"], ["M. PIAGGIO"], ["M. NDIAYE"]] },
       {
         room: "SALLE 6",
         shifts: [["M. FRAYON", "M. GOMIS"], ["M. FRAYON", "Mme DUFAY"], ["M. FRAYON", "Mme CHABERT"]],
@@ -185,7 +185,7 @@ export const scheduleData: ScheduleData = {
         room: "SALLE 2",
         shifts: [["Mme DRAME", "Mme CHABERT"], ["Mme DRAME", "M. NDOYE"], ["Mme DRAME", "Mme PEREZ"]],
       },
-      { room: "SALLE 1", shifts: [["Mme DIADIO"], ["M. PIAGGIO"], ["M. DAVID"]] },
+      { room: "SALLE 1", shifts: [["Mme DIADIO"], ["M. DIANDY"], ["M. DAVID"]] },
       { room: "Couloir et soutien", shifts: [["M. FALL B."], ["M. THOMAS"], []] },
     ],
   },


### PR DESCRIPTION
### Motivation
- Reflect the requested swap of supervisors for the DNB mathematics slot by exchanging M. DIANDY and M. PIAGGIO between Salle 1 and Salle 7.

### Description
- Updated `src/features/bac-dnb-surveillance/data/scheduleData.ts` to replace `M. DIANDY` with `M. PIAGGIO` in the `SALLE 7` shifts and to replace `M. PIAGGIO` with `M. DIANDY` in the `SALLE 1` shifts.

### Testing
- Ran `git diff --check` (no issues) and `npm run build` (build succeeded after installing dependencies with `npm install --legacy-peer-deps`), while `npm ci` initially failed due to an existing ESLint peer-dependency conflict.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32501389b0833195c16462ce96bed4)